### PR TITLE
Adding the UI to list and create / update projects.

### DIFF
--- a/packages/api/src/datasources/projects.ts
+++ b/packages/api/src/datasources/projects.ts
@@ -38,19 +38,19 @@ export class ProjectsAPI extends DataSource {
   }
 
   async createProject(project) {
-    const { result } = await getMongoDB()
-    .collection('projects')
-    .insertOne(project);
+    await getMongoDB()
+      .collection('projects')
+      .insertOne(project);
     // this needs sanitization and validation it would be great to share the logic between director and the api.
     // its hard to do with the seperate yarn workspaces.
-    return await result;
+    return project;
   }
 
   async updateProject(project) {
-    const result = await getMongoDB()
+    await getMongoDB()
       .collection('projects')
       .replaceOne({'projectId':project.projectId}, project);
-    return result;
+    return project;
   }
 
   async getProjects({ orderDirection, filters }) {

--- a/packages/api/src/datasources/projects.ts
+++ b/packages/api/src/datasources/projects.ts
@@ -24,6 +24,35 @@ export class ProjectsAPI extends DataSource {
     await init();
   }
 
+  async getProjectById(id: string) {
+    const result = getMongoDB()
+      .collection('projects')
+      .aggregate([{
+          $match: {
+            projectId: id
+          }
+        }
+      ]);
+
+    return (await result.toArray()).pop();
+  }
+
+  async createProject(project) {
+    const { result } = await getMongoDB()
+    .collection('projects')
+    .insertOne(project);
+    // this needs sanitization and validation it would be great to share the logic between director and the api.
+    // its hard to do with the seperate yarn workspaces.
+    return await result;
+  }
+
+  async updateProject(project) {
+    const result = await getMongoDB()
+      .collection('projects')
+      .replaceOne({'projectId':project.projectId}, project);
+    return result;
+  }
+
   async getProjects({ orderDirection, filters }) {
     const aggregationPipeline = filtersToAggregations(filters)
       .concat([getSortByAggregation(orderDirection)])
@@ -35,5 +64,22 @@ export class ProjectsAPI extends DataSource {
       .toArray();
 
     return results;
+  }
+
+  async deleteProjectsByIds(projectIds: string[]) {
+    const projectResult = await getMongoDB()
+      .collection('projects')
+      .deleteMany({
+        projectId: {
+          $in: projectIds,
+        },
+      });
+    return {
+      success: projectResult.result.ok === 1,
+      message: `${projectResult.deletedCount} document${
+        projectResult.deletedCount > 1 ? 's' : ''
+      } deleted`,
+      projectIds: projectResult.result.ok === 1 ? projectIds : [],
+    };
   }
 }

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1,16 +1,7 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X];
-} &
-  { [P in K]-?: NonNullable<T[P]> };
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -35,6 +26,14 @@ export type CypressConfig = {
   __typename?: 'CypressConfig';
   video: Scalars['Boolean'];
   videoUploadOnPasses: Scalars['Boolean'];
+};
+
+
+export type DeleteProjectResponse = {
+  __typename?: 'DeleteProjectResponse';
+  success: Scalars['Boolean'];
+  message: Scalars['String'];
+  projectIds: Array<Maybe<Scalars['ID']>>;
 };
 
 export type DeleteRunResponse = {
@@ -120,24 +119,45 @@ export type Mutation = {
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
+  deleteProject: DeleteProjectResponse;
+  createProject: Project;
+  updateProject: Project;
 };
+
 
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
+
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
+
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
   endDate: Scalars['DateTime'];
 };
 
+
+export type MutationDeleteProjectArgs = {
+  projectId: Scalars['ID'];
+};
+
+
+export type MutationCreateProjectArgs = {
+  project?: Maybe<ProjectInput>;
+};
+
+
+export type MutationUpdateProjectArgs = {
+  project?: Maybe<ProjectInput>;
+};
+
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC',
+  Asc = 'ASC'
 }
 
 export type PartialRun = {
@@ -153,19 +173,31 @@ export type Project = {
   projectId: Scalars['String'];
 };
 
+export type ProjectInput = {
+  projectId: Scalars['String'];
+};
+
 export type Query = {
   __typename?: 'Query';
   projects: Array<Maybe<Project>>;
+  project?: Maybe<Project>;
   runs: Array<Maybe<Run>>;
   runFeed: RunFeed;
   run?: Maybe<Run>;
   instance?: Maybe<Instance>;
 };
 
+
 export type QueryProjectsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
+
+
+export type QueryProjectArgs = {
+  id: Scalars['ID'];
+};
+
 
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
@@ -173,14 +205,17 @@ export type QueryRunsArgs = {
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
@@ -229,7 +264,10 @@ export type RunSpec = {
   claimedAt?: Maybe<Scalars['String']>;
 };
 
+
+
 export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
@@ -240,9 +278,7 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> =
-  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
-  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -268,25 +304,9 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >;
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -294,26 +314,12 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -322,19 +328,11 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (
-  obj: T,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -349,8 +347,8 @@ export type ResolversTypes = {
   Filters: Filters;
   String: ResolverTypeWrapper<Scalars['String']>;
   Project: ResolverTypeWrapper<Project>;
-  Run: ResolverTypeWrapper<Run>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
+  Run: ResolverTypeWrapper<Run>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
   RunMeta: ResolverTypeWrapper<RunMeta>;
   Commit: ResolverTypeWrapper<Commit>;
@@ -369,6 +367,8 @@ export type ResolversTypes = {
   RunSpec: ResolverTypeWrapper<RunSpec>;
   Mutation: ResolverTypeWrapper<{}>;
   DeleteRunResponse: ResolverTypeWrapper<DeleteRunResponse>;
+  DeleteProjectResponse: ResolverTypeWrapper<DeleteProjectResponse>;
+  ProjectInput: ProjectInput;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -377,8 +377,8 @@ export type ResolversParentTypes = {
   Filters: Filters;
   String: Scalars['String'];
   Project: Project;
-  Run: Run;
   ID: Scalars['ID'];
+  Run: Run;
   DateTime: Scalars['DateTime'];
   RunMeta: RunMeta;
   Commit: Commit;
@@ -397,292 +397,142 @@ export type ResolversParentTypes = {
   RunSpec: RunSpec;
   Mutation: {};
   DeleteRunResponse: DeleteRunResponse;
+  DeleteProjectResponse: DeleteProjectResponse;
+  ProjectInput: ProjectInput;
 };
 
-export type CommitResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']
-> = {
+export type CommitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']> = {
   sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorName?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  authorEmail?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  authorName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authorEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  remoteOrigin?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  remoteOrigin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type CypressConfigResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']
-> = {
+export type CypressConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']> = {
   video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  videoUploadOnPasses?: Resolver<
-    ResolversTypes['Boolean'],
-    ParentType,
-    ContextType
-  >;
+  videoUploadOnPasses?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface DateTimeScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
 
-export type DeleteRunResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']
-> = {
+export type DeleteProjectResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteProjectResponse'] = ResolversParentTypes['DeleteProjectResponse']> = {
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  runIds?: Resolver<
-    Array<Maybe<ResolversTypes['ID']>>,
-    ParentType,
-    ContextType
-  >;
+  projectIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type FullRunSpecResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']
-> = {
+export type DeleteRunResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  runIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type FullRunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['FullRunSpec'] = ResolversParentTypes['FullRunSpec']> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  results?: Resolver<
-    Maybe<ResolversTypes['InstanceResults']>,
-    ParentType,
-    ContextType
-  >;
+  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
-> = {
+export type InstanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   run?: Resolver<ResolversTypes['PartialRun'], ParentType, ContextType>;
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  results?: Resolver<
-    Maybe<ResolversTypes['InstanceResults']>,
-    ParentType,
-    ContextType
-  >;
+  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResultsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']
-> = {
+export type InstanceResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']> = {
   stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  tests?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>,
-    ParentType,
-    ContextType
-  >;
+  tests?: Resolver<Maybe<Array<Maybe<ResolversTypes['InstanceTest']>>>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  screenshots?: Resolver<
-    Array<ResolversTypes['InstanceScreeshot']>,
-    ParentType,
-    ContextType
-  >;
-  cypressConfig?: Resolver<
-    Maybe<ResolversTypes['CypressConfig']>,
-    ParentType,
-    ContextType
-  >;
-  reporterStats?: Resolver<
-    Maybe<ResolversTypes['ReporterStats']>,
-    ParentType,
-    ContextType
-  >;
+  screenshots?: Resolver<Array<ResolversTypes['InstanceScreeshot']>, ParentType, ContextType>;
+  cypressConfig?: Resolver<Maybe<ResolversTypes['CypressConfig']>, ParentType, ContextType>;
+  reporterStats?: Resolver<Maybe<ResolversTypes['ReporterStats']>, ParentType, ContextType>;
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceScreeshotResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']
-> = {
+export type InstanceScreeshotResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']> = {
   screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  screenshotURL?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  screenshotURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceStatsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']
-> = {
+export type InstanceStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   pending?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   skipped?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   failures?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockEndedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockDuration?: Resolver<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >;
+  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockEndedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceTestResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']
-> = {
+export type InstanceTestResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']> = {
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  title?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['String']>>>,
-    ParentType,
-    ContextType
-  >;
+  title?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stack?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  wallClockDuration?: Resolver<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >;
+  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
-> = {
-  deleteRun?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunArgs, 'runId'>
-  >;
-  deleteRuns?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunsArgs, 'runIds'>
-  >;
-  deleteRunsInDateRange?: Resolver<
-    ResolversTypes['DeleteRunResponse'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>
-  >;
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  deleteRun?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunArgs, 'runId'>>;
+  deleteRuns?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsArgs, 'runIds'>>;
+  deleteRunsInDateRange?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>>;
+  deleteProject?: Resolver<ResolversTypes['DeleteProjectResponse'], ParentType, ContextType, RequireFields<MutationDeleteProjectArgs, 'projectId'>>;
+  createProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationCreateProjectArgs, never>>;
+  updateProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationUpdateProjectArgs, never>>;
 };
 
-export type PartialRunResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']
-> = {
+export type PartialRunResolvers<ContextType = any, ParentType extends ResolversParentTypes['PartialRun'] = ResolversParentTypes['PartialRun']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<
-    Array<Maybe<ResolversTypes['RunSpec']>>,
-    ParentType,
-    ContextType
-  >;
+  specs?: Resolver<Array<Maybe<ResolversTypes['RunSpec']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type ProjectResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']
-> = {
+export type ProjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']> = {
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = {
-  projects?: Resolver<
-    Array<Maybe<ResolversTypes['Project']>>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryProjectsArgs, 'orderDirection' | 'filters'>
-  >;
-  runs?: Resolver<
-    Array<Maybe<ResolversTypes['Run']>>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>
-  >;
-  runFeed?: Resolver<
-    ResolversTypes['RunFeed'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunFeedArgs, 'filters'>
-  >;
-  run?: Resolver<
-    Maybe<ResolversTypes['Run']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryRunArgs, 'id'>
-  >;
-  instance?: Resolver<
-    Maybe<ResolversTypes['Instance']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryInstanceArgs, 'id'>
-  >;
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  projects?: Resolver<Array<Maybe<ResolversTypes['Project']>>, ParentType, ContextType, RequireFields<QueryProjectsArgs, 'orderDirection' | 'filters'>>;
+  project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'id'>>;
+  runs?: Resolver<Array<Maybe<ResolversTypes['Run']>>, ParentType, ContextType, RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>>;
+  runFeed?: Resolver<ResolversTypes['RunFeed'], ParentType, ContextType, RequireFields<QueryRunFeedArgs, 'filters'>>;
+  run?: Resolver<Maybe<ResolversTypes['Run']>, ParentType, ContextType, RequireFields<QueryRunArgs, 'id'>>;
+  instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;
 };
 
-export type ReporterStatsResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']
-> = {
+export type ReporterStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -694,62 +544,34 @@ export type ReporterStatsResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']
-> = {
+export type RunResolvers<ContextType = any, ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<Maybe<ResolversTypes['RunMeta']>, ParentType, ContextType>;
-  specs?: Resolver<
-    Array<Maybe<ResolversTypes['FullRunSpec']>>,
-    ParentType,
-    ContextType
-  >;
+  specs?: Resolver<Array<Maybe<ResolversTypes['FullRunSpec']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunFeedResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']
-> = {
+export type RunFeedResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']> = {
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunMetaResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']
-> = {
+export type RunMetaResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']> = {
   groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  ciBuildId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  projectId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  ciBuildId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  projectId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunSpecResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']
-> = {
+export type RunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   claimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  claimedAt?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -757,6 +579,7 @@ export type Resolvers<ContextType = any> = {
   Commit?: CommitResolvers<ContextType>;
   CypressConfig?: CypressConfigResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
+  DeleteProjectResponse?: DeleteProjectResponseResolvers<ContextType>;
   DeleteRunResponse?: DeleteRunResponseResolvers<ContextType>;
   FullRunSpec?: FullRunSpecResolvers<ContextType>;
   Instance?: InstanceResolvers<ContextType>;
@@ -774,6 +597,7 @@ export type Resolvers<ContextType = any> = {
   RunMeta?: RunMetaResolvers<ContextType>;
   RunSpec?: RunSpecResolvers<ContextType>;
 };
+
 
 /**
  * @deprecated

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -1,7 +1,5 @@
-import { DataSource } from 'apollo-datasource';
 import { GraphQLDateTime } from 'graphql-iso-date';
 import { AppDatasources } from '@src/datasources/types';
-import { type } from 'os';
 
 type Project = {
   projectId: string,

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -15,6 +15,7 @@ type Query {
     orderDirection: OrderingOptions = DESC
     filters: [Filters] = null
   ): [Project]!
+  project(id: ID!): Project
   runs(
     orderDirection: OrderingOptions = DESC
     cursor: String = null
@@ -26,6 +27,10 @@ type Query {
 }
 
 type Project {
+  projectId: String!
+}
+
+input ProjectInput {
   projectId: String!
 }
 
@@ -157,10 +162,19 @@ type Mutation {
     startDate: DateTime!
     endDate: DateTime!
   ): DeleteRunResponse!
+  deleteProject(projectId: ID!): DeleteProjectResponse!
+  createProject(project: ProjectInput): Project!
+  updateProject(project: ProjectInput): Project!
 }
 
 type DeleteRunResponse {
   success: Boolean!
   message: String!
   runIds: [ID]!
+}
+
+type DeleteProjectResponse {
+  success: Boolean!
+  message: String!
+  projectIds: [ID]!
 }

--- a/packages/dashboard/src/Root.tsx
+++ b/packages/dashboard/src/Root.tsx
@@ -10,6 +10,7 @@ import { Header } from './components/layout/header';
 import { Content } from './components/layout/content';
 
 import { ProjectsView } from './views/ProjectsView';
+import { ProjectEditView } from './views/ProjectEditView';
 import { RunsView } from './views/RunsView';
 import { RunDetailsView } from './views/RunDetailsView';
 import { InstanceDetailsView } from './views/InstanceDetailsView';
@@ -63,6 +64,7 @@ export const Root = () => {
             <Content>
               <Route path="/" exact component={ProjectsView} />
               <Route path="/:projectId/runs" component={RunsView} />
+              <Route path="/:projectId/edit" component={ProjectEditView} />
               <Route path="/run/:id" component={RunDetailsView} />
               <Route
                 path="/instance/:id"

--- a/packages/dashboard/src/components/project/projectListItem.tsx
+++ b/packages/dashboard/src/components/project/projectListItem.tsx
@@ -1,0 +1,133 @@
+// import { updateCacheOnDeleteProject } from '@src/lib/run';
+import {
+  Button,
+  Heading,
+  HFlow,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  Text,
+  useCss,
+} from 'bold-ui';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Project,
+  useDeleteProjectMutation
+} from '../../generated/graphql';
+import { Paper } from '../common';
+
+type ProjectListItemProps = {
+  project: Partial<Project>;
+  reloadProjects: Function
+};
+
+export function ProjectListItem({ project, reloadProjects }: ProjectListItemProps) {
+  const { css } = useCss();
+  const [startDeleteProjectMutation] = useDeleteProjectMutation({
+    variables: {
+      projectId: project.projectId,
+    },
+    // update: updateCacheOnDeleteProject,
+  });
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [shouldShowModal, setShowModal] = useState(false);
+
+  function deleteProject() {
+    setDeleting(true);
+    startDeleteProjectMutation().then((result) => {
+      if (result.errors) {
+        setDeleteError(result.errors[0].message);
+        setDeleting(false);
+      } else {
+        setDeleting(false);
+        setShowModal(false);
+      }
+      reloadProjects();
+    }).catch((error) => {
+      setDeleting(false);
+      setDeleteError(error.toString());
+    });
+  }
+
+  return (
+    <>
+      <Modal
+        size="small"
+        onClose={() => setShowModal(false)}
+        open={shouldShowModal}
+      >
+        <ModalBody>
+          <HFlow alignItems="center">
+            <Icon
+              icon="exclamationTriangleFilled"
+              style={{ marginRight: '0.5rem' }}
+              size={3}
+              fill="danger"
+            />
+            <div>
+              <Heading level={1}>Delete project {project.projectId}?</Heading>
+              <Heading level={5}>
+                Deleting project will permanently delete the associated data (project, run,
+                instances, test results). Running tests associated with the project
+                will fail.
+              </Heading>
+              {deleteError && <p>Delete error: {deleteError}</p>}
+            </div>
+          </HFlow>
+        </ModalBody>
+        <ModalFooter>
+          <HFlow justifyContent="flex-end">
+            <Button
+              kind="normal"
+              skin="ghost"
+              onClick={() => setShowModal(false)}
+            >
+              <Text color="inherit">Cancel</Text>
+            </Button>
+            <Button
+              kind="danger"
+              skin="ghost"
+              onClick={deleteProject}
+              disabled={deleting}
+            >
+              <Icon icon="trashOutline" style={{ marginRight: '0.5rem' }} />
+              <Text color="inherit">{deleting ? 'Deleting' : 'Delete'}</Text>
+            </Button>
+          </HFlow>
+        </ModalFooter>
+      </Modal>
+      <Paper>
+        <HFlow justifyContent="space-between">
+          <Heading level={1}>
+            <Link className={
+                css`
+                  vertical-align: middle;
+                `
+              }
+              to={`/${project.projectId}/runs`}
+            >
+              {project.projectId}
+            </Link>
+            <Button
+              kind="normal"
+              size="small"
+              skin="ghost"
+              style={{
+                verticalAlign: 'middle',
+                marginLeft: '10px',
+              }}>
+              <Icon icon="penFilled"/>
+            </Button>
+          </Heading>
+          <Button kind="danger" skin="ghost" onClick={() => setShowModal(true)}>
+            <Icon icon="trashOutline" style={{ marginRight: '0.5rem' }} />
+            <Text color="inherit">Delete</Text>
+          </Button>
+        </HFlow>
+      </Paper>
+    </>
+  );
+}

--- a/packages/dashboard/src/components/project/projectListItem.tsx
+++ b/packages/dashboard/src/components/project/projectListItem.tsx
@@ -112,6 +112,8 @@ export function ProjectListItem({ project, reloadProjects }: ProjectListItemProp
               {project.projectId}
             </Link>
             <Button
+              component="a"
+              href={`/${project.projectId}/edit`}
               kind="normal"
               size="small"
               skin="ghost"

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
 };
 
 export type Commit = {
-  __typename?: 'Commit';
+   __typename?: 'Commit';
   sha?: Maybe<Scalars['String']>;
   branch?: Maybe<Scalars['String']>;
   authorName?: Maybe<Scalars['String']>;
@@ -23,13 +23,21 @@ export type Commit = {
 };
 
 export type CypressConfig = {
-  __typename?: 'CypressConfig';
+   __typename?: 'CypressConfig';
   video: Scalars['Boolean'];
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
+
+export type DeleteProjectResponse = {
+   __typename?: 'DeleteProjectResponse';
+  success: Scalars['Boolean'];
+  message: Scalars['String'];
+  projectIds: Array<Maybe<Scalars['ID']>>;
+};
+
 export type DeleteRunResponse = {
-  __typename?: 'DeleteRunResponse';
+   __typename?: 'DeleteRunResponse';
   success: Scalars['Boolean'];
   message: Scalars['String'];
   runIds: Array<Maybe<Scalars['ID']>>;
@@ -41,7 +49,7 @@ export type Filters = {
 };
 
 export type FullRunSpec = {
-  __typename?: 'FullRunSpec';
+   __typename?: 'FullRunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
@@ -50,7 +58,7 @@ export type FullRunSpec = {
 };
 
 export type Instance = {
-  __typename?: 'Instance';
+   __typename?: 'Instance';
   runId: Scalars['ID'];
   run: PartialRun;
   spec: Scalars['String'];
@@ -59,7 +67,7 @@ export type Instance = {
 };
 
 export type InstanceResults = {
-  __typename?: 'InstanceResults';
+   __typename?: 'InstanceResults';
   stats: InstanceStats;
   tests?: Maybe<Array<Maybe<InstanceTest>>>;
   error?: Maybe<Scalars['String']>;
@@ -71,7 +79,7 @@ export type InstanceResults = {
 };
 
 export type InstanceScreeshot = {
-  __typename?: 'InstanceScreeshot';
+   __typename?: 'InstanceScreeshot';
   screenshotId: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   testId: Scalars['String'];
@@ -82,7 +90,7 @@ export type InstanceScreeshot = {
 };
 
 export type InstanceStats = {
-  __typename?: 'InstanceStats';
+   __typename?: 'InstanceStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -95,7 +103,7 @@ export type InstanceStats = {
 };
 
 export type InstanceTest = {
-  __typename?: 'InstanceTest';
+   __typename?: 'InstanceTest';
   testId: Scalars['String'];
   title?: Maybe<Array<Maybe<Scalars['String']>>>;
   state?: Maybe<Scalars['String']>;
@@ -107,32 +115,53 @@ export type InstanceTest = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+   __typename?: 'Mutation';
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
+  deleteProject: DeleteProjectResponse;
+  createProject: Project;
+  updateProject: Project;
 };
+
 
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
+
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
+
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
   endDate: Scalars['DateTime'];
 };
 
+
+export type MutationDeleteProjectArgs = {
+  projectId: Scalars['ID'];
+};
+
+
+export type MutationCreateProjectArgs = {
+  project?: Maybe<ProjectInput>;
+};
+
+
+export type MutationUpdateProjectArgs = {
+  project?: Maybe<ProjectInput>;
+};
+
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC',
+  Asc = 'ASC'
 }
 
 export type PartialRun = {
-  __typename?: 'PartialRun';
+   __typename?: 'PartialRun';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -140,23 +169,35 @@ export type PartialRun = {
 };
 
 export type Project = {
-  __typename?: 'Project';
+   __typename?: 'Project';
+  projectId: Scalars['String'];
+};
+
+export type ProjectInput = {
   projectId: Scalars['String'];
 };
 
 export type Query = {
-  __typename?: 'Query';
+   __typename?: 'Query';
   projects: Array<Maybe<Project>>;
+  project?: Maybe<Project>;
   runs: Array<Maybe<Run>>;
   runFeed: RunFeed;
   run?: Maybe<Run>;
   instance?: Maybe<Instance>;
 };
 
+
 export type QueryProjectsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
+
+
+export type QueryProjectArgs = {
+  id: Scalars['ID'];
+};
+
 
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
@@ -164,21 +205,24 @@ export type QueryRunsArgs = {
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
 };
 
 export type ReporterStats = {
-  __typename?: 'ReporterStats';
+   __typename?: 'ReporterStats';
   suites?: Maybe<Scalars['Int']>;
   tests?: Maybe<Scalars['Int']>;
   passes?: Maybe<Scalars['Int']>;
@@ -190,7 +234,7 @@ export type ReporterStats = {
 };
 
 export type Run = {
-  __typename?: 'Run';
+   __typename?: 'Run';
   runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta?: Maybe<RunMeta>;
@@ -198,14 +242,14 @@ export type Run = {
 };
 
 export type RunFeed = {
-  __typename?: 'RunFeed';
+   __typename?: 'RunFeed';
   cursor: Scalars['String'];
   hasMore: Scalars['Boolean'];
   runs: Array<Run>;
 };
 
 export type RunMeta = {
-  __typename?: 'RunMeta';
+   __typename?: 'RunMeta';
   groupId?: Maybe<Scalars['String']>;
   ciBuildId?: Maybe<Scalars['String']>;
   projectId?: Maybe<Scalars['String']>;
@@ -213,321 +257,318 @@ export type RunMeta = {
 };
 
 export type RunSpec = {
-  __typename?: 'RunSpec';
+   __typename?: 'RunSpec';
   spec: Scalars['String'];
   instanceId: Scalars['String'];
   claimed: Scalars['Boolean'];
   claimedAt?: Maybe<Scalars['String']>;
 };
 
+export type CreateProjectMutationVariables = {
+  project?: Maybe<ProjectInput>;
+};
+
+
+export type CreateProjectMutation = (
+  { __typename?: 'Mutation' }
+  & { createProject: (
+    { __typename?: 'Project' }
+    & Pick<Project, 'projectId'>
+  ) }
+);
+
+export type DeleteProjectMutationVariables = {
+  projectId: Scalars['ID'];
+};
+
+
+export type DeleteProjectMutation = (
+  { __typename?: 'Mutation' }
+  & { deleteProject: (
+    { __typename?: 'DeleteProjectResponse' }
+    & Pick<DeleteProjectResponse, 'success' | 'message' | 'projectIds'>
+  ) }
+);
+
 export type DeleteRunMutationVariables = {
   runId: Scalars['ID'];
 };
 
-export type DeleteRunMutation = { __typename?: 'Mutation' } & {
-  deleteRun: { __typename?: 'DeleteRunResponse' } & Pick<
-    DeleteRunResponse,
-    'success' | 'message' | 'runIds'
-  >;
-};
+
+export type DeleteRunMutation = (
+  { __typename?: 'Mutation' }
+  & { deleteRun: (
+    { __typename?: 'DeleteRunResponse' }
+    & Pick<DeleteRunResponse, 'success' | 'message' | 'runIds'>
+  ) }
+);
 
 export type GetInstanceQueryVariables = {
   instanceId: Scalars['ID'];
 };
 
-export type GetInstanceQuery = { __typename?: 'Query' } & {
-  instance?: Maybe<
-    { __typename?: 'Instance' } & Pick<
-      Instance,
-      'instanceId' | 'runId' | 'spec'
-    > & {
-        run: { __typename?: 'PartialRun' } & {
-          meta?: Maybe<
-            { __typename?: 'RunMeta' } & Pick<
-              RunMeta,
-              'ciBuildId' | 'projectId'
-            > & {
-                commit?: Maybe<
-                  { __typename?: 'Commit' } & Pick<
-                    Commit,
-                    | 'sha'
-                    | 'branch'
-                    | 'authorName'
-                    | 'authorEmail'
-                    | 'remoteOrigin'
-                    | 'message'
-                  >
-                >;
-              }
-          >;
-        };
-        results?: Maybe<
-          { __typename?: 'InstanceResults' } & Pick<
-            InstanceResults,
-            'videoUrl'
-          > & {
-              stats: { __typename?: 'InstanceStats' } & Pick<
-                InstanceStats,
-                | 'suites'
-                | 'tests'
-                | 'passes'
-                | 'pending'
-                | 'skipped'
-                | 'failures'
-                | 'wallClockDuration'
-                | 'wallClockStartedAt'
-                | 'wallClockEndedAt'
-              >;
-              tests?: Maybe<
-                Array<
-                  Maybe<
-                    { __typename?: 'InstanceTest' } & Pick<
-                      InstanceTest,
-                      | 'testId'
-                      | 'wallClockDuration'
-                      | 'wallClockStartedAt'
-                      | 'state'
-                      | 'error'
-                      | 'stack'
-                      | 'title'
-                    >
-                  >
-                >
-              >;
-              screenshots: Array<
-                { __typename?: 'InstanceScreeshot' } & Pick<
-                  InstanceScreeshot,
-                  | 'testId'
-                  | 'screenshotId'
-                  | 'height'
-                  | 'width'
-                  | 'screenshotURL'
-                >
-              >;
-              cypressConfig?: Maybe<
-                { __typename?: 'CypressConfig' } & Pick<
-                  CypressConfig,
-                  'video' | 'videoUploadOnPasses'
-                >
-              >;
-            }
-        >;
-      }
-  >;
+
+export type GetInstanceQuery = (
+  { __typename?: 'Query' }
+  & { instance?: Maybe<(
+    { __typename?: 'Instance' }
+    & Pick<Instance, 'instanceId' | 'runId' | 'spec'>
+    & { run: (
+      { __typename?: 'PartialRun' }
+      & { meta?: Maybe<(
+        { __typename?: 'RunMeta' }
+        & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+        & { commit?: Maybe<(
+          { __typename?: 'Commit' }
+          & Pick<Commit, 'sha' | 'branch' | 'authorName' | 'authorEmail' | 'remoteOrigin' | 'message'>
+        )> }
+      )> }
+    ), results?: Maybe<(
+      { __typename?: 'InstanceResults' }
+      & Pick<InstanceResults, 'videoUrl'>
+      & { stats: (
+        { __typename?: 'InstanceStats' }
+        & Pick<InstanceStats, 'suites' | 'tests' | 'passes' | 'pending' | 'skipped' | 'failures' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+      ), tests?: Maybe<Array<Maybe<(
+        { __typename?: 'InstanceTest' }
+        & Pick<InstanceTest, 'testId' | 'wallClockDuration' | 'wallClockStartedAt' | 'state' | 'error' | 'stack' | 'title'>
+      )>>>, screenshots: Array<(
+        { __typename?: 'InstanceScreeshot' }
+        & Pick<InstanceScreeshot, 'testId' | 'screenshotId' | 'height' | 'width' | 'screenshotURL'>
+      )>, cypressConfig?: Maybe<(
+        { __typename?: 'CypressConfig' }
+        & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+      )> }
+    )> }
+  )> }
+);
+
+export type GetProjectQueryVariables = {
+  projectId: Scalars['ID'];
 };
+
+
+export type GetProjectQuery = (
+  { __typename?: 'Query' }
+  & { project?: Maybe<(
+    { __typename?: 'Project' }
+    & Pick<Project, 'projectId'>
+  )> }
+);
 
 export type GetProjectsQueryVariables = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-export type GetProjectsQuery = { __typename?: 'Query' } & {
-  projects: Array<
-    Maybe<{ __typename?: 'Project' } & Pick<Project, 'projectId'>>
-  >;
-};
+
+export type GetProjectsQuery = (
+  { __typename?: 'Query' }
+  & { projects: Array<Maybe<(
+    { __typename?: 'Project' }
+    & Pick<Project, 'projectId'>
+  )>> }
+);
 
 export type GetRunQueryVariables = {
   runId: Scalars['ID'];
 };
 
-export type GetRunQuery = { __typename?: 'Query' } & {
-  run?: Maybe<
-    { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
-        meta?: Maybe<
-          { __typename?: 'RunMeta' } & Pick<
-            RunMeta,
-            'ciBuildId' | 'projectId'
-          > & {
-              commit?: Maybe<
-                { __typename?: 'Commit' } & Pick<
-                  Commit,
-                  | 'sha'
-                  | 'branch'
-                  | 'remoteOrigin'
-                  | 'message'
-                  | 'authorEmail'
-                  | 'authorName'
-                >
-              >;
-            }
-        >;
-        specs: Array<
-          Maybe<
-            { __typename?: 'FullRunSpec' } & Pick<
-              FullRunSpec,
-              'spec' | 'instanceId' | 'claimed' | 'claimedAt'
-            > & {
-                results?: Maybe<
-                  { __typename?: 'InstanceResults' } & Pick<
-                    InstanceResults,
-                    'videoUrl'
-                  > & {
-                      cypressConfig?: Maybe<
-                        { __typename?: 'CypressConfig' } & Pick<
-                          CypressConfig,
-                          'video' | 'videoUploadOnPasses'
-                        >
-                      >;
-                      tests?: Maybe<
-                        Array<
-                          Maybe<
-                            { __typename?: 'InstanceTest' } & Pick<
-                              InstanceTest,
-                              | 'title'
-                              | 'state'
-                              | 'wallClockDuration'
-                              | 'wallClockStartedAt'
-                            >
-                          >
-                        >
-                      >;
-                      stats: { __typename?: 'InstanceStats' } & Pick<
-                        InstanceStats,
-                        | 'tests'
-                        | 'pending'
-                        | 'passes'
-                        | 'failures'
-                        | 'skipped'
-                        | 'suites'
-                        | 'wallClockDuration'
-                        | 'wallClockStartedAt'
-                        | 'wallClockEndedAt'
-                      >;
-                    }
-                >;
-              }
-          >
-        >;
-      }
-  >;
-};
+
+export type GetRunQuery = (
+  { __typename?: 'Query' }
+  & { run?: Maybe<(
+    { __typename?: 'Run' }
+    & Pick<Run, 'runId' | 'createdAt'>
+    & { meta?: Maybe<(
+      { __typename?: 'RunMeta' }
+      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+      & { commit?: Maybe<(
+        { __typename?: 'Commit' }
+        & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
+      )> }
+    )>, specs: Array<Maybe<(
+      { __typename?: 'FullRunSpec' }
+      & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed' | 'claimedAt'>
+      & { results?: Maybe<(
+        { __typename?: 'InstanceResults' }
+        & Pick<InstanceResults, 'videoUrl'>
+        & { cypressConfig?: Maybe<(
+          { __typename?: 'CypressConfig' }
+          & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+        )>, tests?: Maybe<Array<Maybe<(
+          { __typename?: 'InstanceTest' }
+          & Pick<InstanceTest, 'title' | 'state' | 'wallClockDuration' | 'wallClockStartedAt'>
+        )>>>, stats: (
+          { __typename?: 'InstanceStats' }
+          & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+        ) }
+      )> }
+    )>> }
+  )> }
+);
 
 export type GetRunsByProjectIdLimitedToTimingQueryVariables = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-export type GetRunsByProjectIdLimitedToTimingQuery = {
-  __typename?: 'Query';
-} & {
-  runs: Array<
-    Maybe<
-      { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
-          meta?: Maybe<
-            { __typename?: 'RunMeta' } & Pick<
-              RunMeta,
-              'ciBuildId' | 'projectId'
-            >
-          >;
-          specs: Array<
-            Maybe<
-              { __typename?: 'FullRunSpec' } & Pick<FullRunSpec, 'spec'> & {
-                  results?: Maybe<
-                    { __typename?: 'InstanceResults' } & {
-                      stats: { __typename?: 'InstanceStats' } & Pick<
-                        InstanceStats,
-                        'wallClockDuration'
-                      >;
-                    }
-                  >;
-                }
-            >
-          >;
-        }
-    >
-  >;
-};
+
+export type GetRunsByProjectIdLimitedToTimingQuery = (
+  { __typename?: 'Query' }
+  & { runs: Array<Maybe<(
+    { __typename?: 'Run' }
+    & Pick<Run, 'runId' | 'createdAt'>
+    & { meta?: Maybe<(
+      { __typename?: 'RunMeta' }
+      & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+    )>, specs: Array<Maybe<(
+      { __typename?: 'FullRunSpec' }
+      & Pick<FullRunSpec, 'spec'>
+      & { results?: Maybe<(
+        { __typename?: 'InstanceResults' }
+        & { stats: (
+          { __typename?: 'InstanceStats' }
+          & Pick<InstanceStats, 'wallClockDuration'>
+        ) }
+      )> }
+    )>> }
+  )>> }
+);
 
 export type GetRunsFeedQueryVariables = {
   cursor?: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-export type GetRunsFeedQuery = { __typename?: 'Query' } & {
-  runFeed: { __typename?: 'RunFeed' } & Pick<RunFeed, 'cursor' | 'hasMore'> & {
-      runs: Array<
-        { __typename?: 'Run' } & Pick<Run, 'runId' | 'createdAt'> & {
-            meta?: Maybe<
-              { __typename?: 'RunMeta' } & Pick<
-                RunMeta,
-                'ciBuildId' | 'projectId'
-              > & {
-                  commit?: Maybe<
-                    { __typename?: 'Commit' } & Pick<
-                      Commit,
-                      | 'sha'
-                      | 'branch'
-                      | 'remoteOrigin'
-                      | 'message'
-                      | 'authorEmail'
-                      | 'authorName'
-                    >
-                  >;
-                }
-            >;
-            specs: Array<
-              Maybe<
-                { __typename?: 'FullRunSpec' } & Pick<
-                  FullRunSpec,
-                  'spec' | 'instanceId' | 'claimed'
-                > & {
-                    results?: Maybe<
-                      { __typename?: 'InstanceResults' } & Pick<
-                        InstanceResults,
-                        'videoUrl'
-                      > & {
-                          cypressConfig?: Maybe<
-                            { __typename?: 'CypressConfig' } & Pick<
-                              CypressConfig,
-                              'video' | 'videoUploadOnPasses'
-                            >
-                          >;
-                          tests?: Maybe<
-                            Array<
-                              Maybe<
-                                { __typename?: 'InstanceTest' } & Pick<
-                                  InstanceTest,
-                                  'title' | 'state'
-                                >
-                              >
-                            >
-                          >;
-                          stats: { __typename?: 'InstanceStats' } & Pick<
-                            InstanceStats,
-                            | 'tests'
-                            | 'pending'
-                            | 'passes'
-                            | 'failures'
-                            | 'skipped'
-                            | 'suites'
-                            | 'wallClockDuration'
-                            | 'wallClockStartedAt'
-                            | 'wallClockEndedAt'
-                          >;
-                        }
-                    >;
-                  }
-              >
-            >;
-          }
-      >;
-    };
+
+export type GetRunsFeedQuery = (
+  { __typename?: 'Query' }
+  & { runFeed: (
+    { __typename?: 'RunFeed' }
+    & Pick<RunFeed, 'cursor' | 'hasMore'>
+    & { runs: Array<(
+      { __typename?: 'Run' }
+      & Pick<Run, 'runId' | 'createdAt'>
+      & { meta?: Maybe<(
+        { __typename?: 'RunMeta' }
+        & Pick<RunMeta, 'ciBuildId' | 'projectId'>
+        & { commit?: Maybe<(
+          { __typename?: 'Commit' }
+          & Pick<Commit, 'sha' | 'branch' | 'remoteOrigin' | 'message' | 'authorEmail' | 'authorName'>
+        )> }
+      )>, specs: Array<Maybe<(
+        { __typename?: 'FullRunSpec' }
+        & Pick<FullRunSpec, 'spec' | 'instanceId' | 'claimed'>
+        & { results?: Maybe<(
+          { __typename?: 'InstanceResults' }
+          & Pick<InstanceResults, 'videoUrl'>
+          & { cypressConfig?: Maybe<(
+            { __typename?: 'CypressConfig' }
+            & Pick<CypressConfig, 'video' | 'videoUploadOnPasses'>
+          )>, tests?: Maybe<Array<Maybe<(
+            { __typename?: 'InstanceTest' }
+            & Pick<InstanceTest, 'title' | 'state'>
+          )>>>, stats: (
+            { __typename?: 'InstanceStats' }
+            & Pick<InstanceStats, 'tests' | 'pending' | 'passes' | 'failures' | 'skipped' | 'suites' | 'wallClockDuration' | 'wallClockStartedAt' | 'wallClockEndedAt'>
+          ) }
+        )> }
+      )>> }
+    )> }
+  ) }
+);
+
+export type UpdateProjectMutationVariables = {
+  project: ProjectInput;
 };
 
-export const DeleteRunDocument = gql`
-  mutation deleteRun($runId: ID!) {
-    deleteRun(runId: $runId) {
-      success
-      message
-      runIds
-    }
+
+export type UpdateProjectMutation = (
+  { __typename?: 'Mutation' }
+  & { updateProject: (
+    { __typename?: 'Project' }
+    & Pick<Project, 'projectId'>
+  ) }
+);
+
+
+export const CreateProjectDocument = gql`
+    mutation createProject($project: ProjectInput) {
+  createProject(project: $project) {
+    projectId
   }
-`;
-export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<
-  DeleteRunMutation,
-  DeleteRunMutationVariables
->;
+}
+    `;
+export type CreateProjectMutationFn = ApolloReactCommon.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+
+/**
+ * __useCreateProjectMutation__
+ *
+ * To run a mutation, you first call `useCreateProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createProjectMutation, { data, loading, error }] = useCreateProjectMutation({
+ *   variables: {
+ *      project: // value for 'project'
+ *   },
+ * });
+ */
+export function useCreateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
+        return ApolloReactHooks.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, baseOptions);
+      }
+export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
+export type CreateProjectMutationResult = ApolloReactCommon.MutationResult<CreateProjectMutation>;
+export type CreateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
+export const DeleteProjectDocument = gql`
+    mutation deleteProject($projectId: ID!) {
+  deleteProject(projectId: $projectId) {
+    success
+    message
+    projectIds
+  }
+}
+    `;
+export type DeleteProjectMutationFn = ApolloReactCommon.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+
+/**
+ * __useDeleteProjectMutation__
+ *
+ * To run a mutation, you first call `useDeleteProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteProjectMutation, { data, loading, error }] = useDeleteProjectMutation({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useDeleteProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
+        return ApolloReactHooks.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
+      }
+export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
+export type DeleteProjectMutationResult = ApolloReactCommon.MutationResult<DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export const DeleteRunDocument = gql`
+    mutation deleteRun($runId: ID!) {
+  deleteRun(runId: $runId) {
+    success
+    message
+    runIds
+  }
+}
+    `;
+export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
 
 /**
  * __useDeleteRunMutation__
@@ -546,84 +587,69 @@ export type DeleteRunMutationFn = ApolloReactCommon.MutationFunction<
  *   },
  * });
  */
-export function useDeleteRunMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    DeleteRunMutation,
-    DeleteRunMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    DeleteRunMutation,
-    DeleteRunMutationVariables
-  >(DeleteRunDocument, baseOptions);
-}
-export type DeleteRunMutationHookResult = ReturnType<
-  typeof useDeleteRunMutation
->;
-export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<
-  DeleteRunMutation
->;
-export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  DeleteRunMutation,
-  DeleteRunMutationVariables
->;
-export const GetInstanceDocument = gql`
-  query getInstance($instanceId: ID!) {
-    instance(id: $instanceId) {
-      instanceId
-      runId
-      spec
-      run {
-        meta {
-          ciBuildId
-          projectId
-          commit {
-            sha
-            branch
-            authorName
-            authorEmail
-            remoteOrigin
-            message
-          }
-        }
+export function useDeleteRunMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
+        return ApolloReactHooks.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, baseOptions);
       }
-      results {
-        stats {
-          suites
-          tests
-          passes
-          pending
-          skipped
-          failures
-          wallClockDuration
-          wallClockStartedAt
-          wallClockEndedAt
+export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
+export type DeleteRunMutationResult = ApolloReactCommon.MutationResult<DeleteRunMutation>;
+export type DeleteRunMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
+export const GetInstanceDocument = gql`
+    query getInstance($instanceId: ID!) {
+  instance(id: $instanceId) {
+    instanceId
+    runId
+    spec
+    run {
+      meta {
+        ciBuildId
+        projectId
+        commit {
+          sha
+          branch
+          authorName
+          authorEmail
+          remoteOrigin
+          message
         }
-        tests {
-          testId
-          wallClockDuration
-          wallClockStartedAt
-          state
-          error
-          stack
-          title
-        }
-        screenshots {
-          testId
-          screenshotId
-          height
-          width
-          screenshotURL
-        }
-        cypressConfig {
-          video
-          videoUploadOnPasses
-        }
-        videoUrl
       }
     }
+    results {
+      stats {
+        suites
+        tests
+        passes
+        pending
+        skipped
+        failures
+        wallClockDuration
+        wallClockStartedAt
+        wallClockEndedAt
+      }
+      tests {
+        testId
+        wallClockDuration
+        wallClockStartedAt
+        state
+        error
+        stack
+        title
+      }
+      screenshots {
+        testId
+        screenshotId
+        height
+        width
+        screenshotURL
+      }
+      cypressConfig {
+        video
+        videoUploadOnPasses
+      }
+      videoUrl
+    }
   }
-`;
+}
+    `;
 
 /**
  * __useGetInstanceQuery__
@@ -641,43 +667,55 @@ export const GetInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetInstanceQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(
-    GetInstanceDocument,
-    baseOptions
-  );
-}
-export function useGetInstanceLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetInstanceQuery,
-    GetInstanceQueryVariables
-  >(GetInstanceDocument, baseOptions);
-}
+export function useGetInstanceQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
+      }
+export function useGetInstanceLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
+        }
 export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
-export type GetInstanceLazyQueryHookResult = ReturnType<
-  typeof useGetInstanceLazyQuery
->;
-export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<
-  GetInstanceQuery,
-  GetInstanceQueryVariables
->;
-export const GetProjectsDocument = gql`
-  query getProjects($orderDirection: OrderingOptions, $filters: [Filters]) {
-    projects(orderDirection: $orderDirection, filters: $filters) {
-      projectId
-    }
+export type GetInstanceLazyQueryHookResult = ReturnType<typeof useGetInstanceLazyQuery>;
+export type GetInstanceQueryResult = ApolloReactCommon.QueryResult<GetInstanceQuery, GetInstanceQueryVariables>;
+export const GetProjectDocument = gql`
+    query getProject($projectId: ID!) {
+  project(id: $projectId) {
+    projectId
   }
-`;
+}
+    `;
+
+/**
+ * __useGetProjectQuery__
+ *
+ * To run a query within a React component, call `useGetProjectQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProjectQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetProjectQuery({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useGetProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+      }
+export function useGetProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+        }
+export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
+export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
+export type GetProjectQueryResult = ApolloReactCommon.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
+export const GetProjectsDocument = gql`
+    query getProjects($orderDirection: OrderingOptions, $filters: [Filters]) {
+  projects(orderDirection: $orderDirection, filters: $filters) {
+    projectId
+  }
+}
+    `;
 
 /**
  * __useGetProjectsQuery__
@@ -696,86 +734,65 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetProjectsQuery,
-    GetProjectsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(
-    GetProjectsDocument,
-    baseOptions
-  );
-}
-export function useGetProjectsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetProjectsQuery,
-    GetProjectsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetProjectsQuery,
-    GetProjectsQueryVariables
-  >(GetProjectsDocument, baseOptions);
-}
-export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
-export type GetProjectsLazyQueryHookResult = ReturnType<
-  typeof useGetProjectsLazyQuery
->;
-export type GetProjectsQueryResult = ApolloReactCommon.QueryResult<
-  GetProjectsQuery,
-  GetProjectsQueryVariables
->;
-export const GetRunDocument = gql`
-  query getRun($runId: ID!) {
-    run(id: $runId) {
-      runId
-      createdAt
-      meta {
-        ciBuildId
-        projectId
-        commit {
-          sha
-          branch
-          remoteOrigin
-          message
-          authorEmail
-          authorName
-        }
+export function useGetProjectsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
       }
-      specs {
-        spec
-        instanceId
-        claimed
-        claimedAt
-        results {
-          cypressConfig {
-            video
-            videoUploadOnPasses
-          }
-          videoUrl
-          tests {
-            title
-            state
-            wallClockDuration
-            wallClockStartedAt
-          }
-          stats {
-            tests
-            pending
-            passes
-            failures
-            skipped
-            suites
-            wallClockDuration
-            wallClockStartedAt
-            wallClockEndedAt
-          }
+export function useGetProjectsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
+        }
+export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
+export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
+export type GetProjectsQueryResult = ApolloReactCommon.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
+export const GetRunDocument = gql`
+    query getRun($runId: ID!) {
+  run(id: $runId) {
+    runId
+    createdAt
+    meta {
+      ciBuildId
+      projectId
+      commit {
+        sha
+        branch
+        remoteOrigin
+        message
+        authorEmail
+        authorName
+      }
+    }
+    specs {
+      spec
+      instanceId
+      claimed
+      claimedAt
+      results {
+        cypressConfig {
+          video
+          videoUploadOnPasses
+        }
+        videoUrl
+        tests {
+          title
+          state
+          wallClockDuration
+          wallClockStartedAt
+        }
+        stats {
+          tests
+          pending
+          passes
+          failures
+          skipped
+          suites
+          wallClockDuration
+          wallClockStartedAt
+          wallClockEndedAt
         }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetRunQuery__
@@ -793,57 +810,35 @@ export const GetRunDocument = gql`
  *   },
  * });
  */
-export function useGetRunQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetRunQuery,
-    GetRunQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(
-    GetRunDocument,
-    baseOptions
-  );
-}
-export function useGetRunLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetRunQuery,
-    GetRunQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(
-    GetRunDocument,
-    baseOptions
-  );
-}
+export function useGetRunQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
+      }
+export function useGetRunLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
+        }
 export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
 export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
-export type GetRunQueryResult = ApolloReactCommon.QueryResult<
-  GetRunQuery,
-  GetRunQueryVariables
->;
+export type GetRunQueryResult = ApolloReactCommon.QueryResult<GetRunQuery, GetRunQueryVariables>;
 export const GetRunsByProjectIdLimitedToTimingDocument = gql`
-  query getRunsByProjectIdLimitedToTiming(
-    $orderDirection: OrderingOptions
-    $filters: [Filters]
-  ) {
-    runs(orderDirection: $orderDirection, filters: $filters) {
-      runId
-      createdAt
-      meta {
-        ciBuildId
-        projectId
-      }
-      specs {
-        spec
-        results {
-          stats {
-            wallClockDuration
-          }
+    query getRunsByProjectIdLimitedToTiming($orderDirection: OrderingOptions, $filters: [Filters]) {
+  runs(orderDirection: $orderDirection, filters: $filters) {
+    runId
+    createdAt
+    meta {
+      ciBuildId
+      projectId
+    }
+    specs {
+      spec
+      results {
+        stats {
+          wallClockDuration
         }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetRunsByProjectIdLimitedToTimingQuery__
@@ -862,89 +857,66 @@ export const GetRunsByProjectIdLimitedToTimingDocument = gql`
  *   },
  * });
  */
-export function useGetRunsByProjectIdLimitedToTimingQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetRunsByProjectIdLimitedToTimingQuery,
-    GetRunsByProjectIdLimitedToTimingQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<
-    GetRunsByProjectIdLimitedToTimingQuery,
-    GetRunsByProjectIdLimitedToTimingQueryVariables
-  >(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
-}
-export function useGetRunsByProjectIdLimitedToTimingLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetRunsByProjectIdLimitedToTimingQuery,
-    GetRunsByProjectIdLimitedToTimingQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetRunsByProjectIdLimitedToTimingQuery,
-    GetRunsByProjectIdLimitedToTimingQueryVariables
-  >(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
-}
-export type GetRunsByProjectIdLimitedToTimingQueryHookResult = ReturnType<
-  typeof useGetRunsByProjectIdLimitedToTimingQuery
->;
-export type GetRunsByProjectIdLimitedToTimingLazyQueryHookResult = ReturnType<
-  typeof useGetRunsByProjectIdLimitedToTimingLazyQuery
->;
-export type GetRunsByProjectIdLimitedToTimingQueryResult = ApolloReactCommon.QueryResult<
-  GetRunsByProjectIdLimitedToTimingQuery,
-  GetRunsByProjectIdLimitedToTimingQueryVariables
->;
-export const GetRunsFeedDocument = gql`
-  query getRunsFeed($cursor: String, $filters: [Filters]) {
-    runFeed(cursor: $cursor, filters: $filters) {
-      cursor
-      hasMore
-      runs {
-        runId
-        createdAt
-        meta {
-          ciBuildId
-          projectId
-          commit {
-            sha
-            branch
-            remoteOrigin
-            message
-            authorEmail
-            authorName
-          }
+export function useGetRunsByProjectIdLimitedToTimingQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
+      }
+export function useGetRunsByProjectIdLimitedToTimingLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>(GetRunsByProjectIdLimitedToTimingDocument, baseOptions);
         }
-        specs {
-          spec
-          instanceId
-          claimed
-          results {
-            cypressConfig {
-              video
-              videoUploadOnPasses
-            }
-            videoUrl
-            tests {
-              title
-              state
-            }
-            stats {
-              tests
-              pending
-              passes
-              failures
-              skipped
-              suites
-              wallClockDuration
-              wallClockStartedAt
-              wallClockEndedAt
-            }
+export type GetRunsByProjectIdLimitedToTimingQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingQuery>;
+export type GetRunsByProjectIdLimitedToTimingLazyQueryHookResult = ReturnType<typeof useGetRunsByProjectIdLimitedToTimingLazyQuery>;
+export type GetRunsByProjectIdLimitedToTimingQueryResult = ApolloReactCommon.QueryResult<GetRunsByProjectIdLimitedToTimingQuery, GetRunsByProjectIdLimitedToTimingQueryVariables>;
+export const GetRunsFeedDocument = gql`
+    query getRunsFeed($cursor: String, $filters: [Filters]) {
+  runFeed(cursor: $cursor, filters: $filters) {
+    cursor
+    hasMore
+    runs {
+      runId
+      createdAt
+      meta {
+        ciBuildId
+        projectId
+        commit {
+          sha
+          branch
+          remoteOrigin
+          message
+          authorEmail
+          authorName
+        }
+      }
+      specs {
+        spec
+        instanceId
+        claimed
+        results {
+          cypressConfig {
+            video
+            videoUploadOnPasses
+          }
+          videoUrl
+          tests {
+            title
+            state
+          }
+          stats {
+            tests
+            pending
+            passes
+            failures
+            skipped
+            suites
+            wallClockDuration
+            wallClockStartedAt
+            wallClockEndedAt
           }
         }
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useGetRunsFeedQuery__
@@ -963,33 +935,44 @@ export const GetRunsFeedDocument = gql`
  *   },
  * });
  */
-export function useGetRunsFeedQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
-    GetRunsFeedDocument,
-    baseOptions
-  );
-}
-export function useGetRunsFeedLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    GetRunsFeedQuery,
-    GetRunsFeedQueryVariables
-  >(GetRunsFeedDocument, baseOptions);
-}
+export function useGetRunsFeedQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
+      }
+export function useGetRunsFeedLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
+        }
 export type GetRunsFeedQueryHookResult = ReturnType<typeof useGetRunsFeedQuery>;
-export type GetRunsFeedLazyQueryHookResult = ReturnType<
-  typeof useGetRunsFeedLazyQuery
->;
-export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<
-  GetRunsFeedQuery,
-  GetRunsFeedQueryVariables
->;
+export type GetRunsFeedLazyQueryHookResult = ReturnType<typeof useGetRunsFeedLazyQuery>;
+export type GetRunsFeedQueryResult = ApolloReactCommon.QueryResult<GetRunsFeedQuery, GetRunsFeedQueryVariables>;
+export const UpdateProjectDocument = gql`
+    mutation updateProject($project: ProjectInput!) {
+  updateProject(project: $project) {
+    projectId
+  }
+}
+    `;
+export type UpdateProjectMutationFn = ApolloReactCommon.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+
+/**
+ * __useUpdateProjectMutation__
+ *
+ * To run a mutation, you first call `useUpdateProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateProjectMutation, { data, loading, error }] = useUpdateProjectMutation({
+ *   variables: {
+ *      project: // value for 'project'
+ *   },
+ * });
+ */
+export function useUpdateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
+        return ApolloReactHooks.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, baseOptions);
+      }
+export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
+export type UpdateProjectMutationResult = ApolloReactCommon.MutationResult<UpdateProjectMutation>;
+export type UpdateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;

--- a/packages/dashboard/src/views/InstanceDetailsView.tsx
+++ b/packages/dashboard/src/views/InstanceDetailsView.tsx
@@ -38,13 +38,13 @@ export function InstanceDetailsView({
       navStructure: [
         {
           __typename: 'NavStructureItem',
-          label: data.instance!.run!.meta!.projectId,
-          link: `${data.instance!.run!.meta!.projectId}/runs`,
+          label: data.instance?.run?.meta?.projectId,
+          link: `${data.instance?.run?.meta?.projectId}/runs`,
         },
         {
           __typename: 'NavStructureItem',
-          label: data.instance!.run!.meta!.ciBuildId,
-          link: `run/${data.instance!.runId}`,
+          label: data.instance?.run?.meta?.ciBuildId,
+          link: `run/${data.instance?.runId}`,
         },
         {
           __typename: 'NavStructureItem',

--- a/packages/dashboard/src/views/ProjectEditView.tsx
+++ b/packages/dashboard/src/views/ProjectEditView.tsx
@@ -1,54 +1,162 @@
 import { useApolloClient } from '@apollo/react-hooks';
-import React from 'react';
-import { ProjectListItem } from '../components/project/projectListItem';
-import { useGetProjectQuery } from '../generated/graphql';
-import { Button, Icon, Text, useCss } from 'bold-ui';
-
+import React, { useState } from 'react';
+import { useGetProjectQuery, useCreateProjectMutation, useUpdateProjectMutation } from '../generated/graphql';
+import { Button, Icon, Tooltip, TextField, Grid, Cell } from 'bold-ui';
+import { useHistory } from "react-router-dom";
 
 export function ProjectEditView({
   match: {
     params: { projectId },
   },
 }) {
-  const { css } = useCss();
+  const history = useHistory();
   const apollo = useApolloClient();
-
+  const isNewProject = projectId === '--create-new-project--';
   apollo.writeData({
     data: {
       navStructure: [],
     },
   });
+  
+  const [formState, setFormState] = useState(data?.project || {
+    projectId: isNewProject ? '' : projectId,
+    //other project fields
+  });
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
 
-  const { loading, error, data, refetch } = useGetProjectQuery({
+  const {loading, error, data} = useGetProjectQuery({
     variables: {
       projectId: projectId
     }
   });
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>{error.toString()}</p>;
-  if (!data) {
-    return <p>No data</p>;
-  }
-  if (!data.project) {
-    return <p>Not a recognized project</p>;
+  const [startCreateProjectMutation] = useCreateProjectMutation({
+    variables:{
+      project: formState
+    }
+  });
+
+  const [startUpdateProjectMutation] = useUpdateProjectMutation ({
+    variables:{
+      project: formState
+    }
+  });
+
+
+  function updateProject() {
+    setUpdating(true);
+    startUpdateProjectMutation().then((result) => {
+      if (result.errors) {
+        setUpdateError(result.errors[0].message);
+      } else {
+        history.push(`/${result.data?.updateProject.projectId}/runs`);
+      }
+      setUpdating(false);
+    }).catch((error) => {
+      setUpdating(false);
+      setUpdateError(error.toString());
+    });
   }
 
-  const project = data.project;
+  function createProject() {
+    setCreating(true);
+    startCreateProjectMutation().then((result) => {
+      if (result.errors) {
+        setCreateError(result.errors[0].message);
+      } else {
+        history.push(`/${result.data?.createProject.projectId}/runs`);
+      }
+      setCreating(false);
+    }).catch((error) => {
+      setCreating(false);
+      setCreateError(error.toString());
+    });
+  }
+
+  if (!isNewProject) {
+    if (loading) return <p>Loading...</p>;
+    if (error) return <p>{error.toString()}</p>;
+    if (!data) {
+      return <p>No data</p>;
+    }
+    if (!data.project) {
+      return <p>Not a recognized project</p>;
+    }
+  }
+
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (isNewProject) {
+      createProject();
+    }else {
+      // updateProject();
+    }
+  }
+
+  const handleChange = (name: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = e.target
+
+    setFormState(state => ({
+      ...state,
+      [name]: el.type === 'checkbox' ? el.checked : el.value,
+    }))
+  }
 
   return (
-    <>
-      <div className={css`
-        display: flex;
-        flex-direction: row-reverse;
-      `}>
-        <Button>
-          <Icon style={{ marginRight: '0.5rem' }} icon="plus"/>
-          <Text color="inherit">New Project</Text>
+    <form onSubmit={handleSubmit}>
+      {createError || updateError ? (
+        <div>
+          {createError || updateError}
+        </div>
+      ): null}
+      <Grid wrap>
+        <Cell xs={6}>
+          <TextField
+            name='projectId'
+            label='Project Id'
+            placeholder='Enter your "projectId"'
+            value={formState.projectId}
+            onChange={handleChange('projectId')}
+            disabled={!isNewProject || creating || updating || loading}
+            required
+          />
+        </Cell>
+        <div style={{
+          display: 'flex',
+          alignSelf: 'flex-end',
+          marginBottom: '14px'
+        }}>
+          <Tooltip text='This must match the "projectId" value in your cypress.json configuration.'>
+            <Icon icon='infoCircleOutline' style={{}}/>
+          </Tooltip>
+        </div>
+      </Grid>
+
+      <div style={{marginTop:'32px'}}>
+        <Button
+          style={{marginRight:'15px'}}
+          component="a"
+          href="/"
+          disabled={creating || updating}
+        >
+          Cancel
+        </Button>
+        {/*
+          You cannot update a project id once it is created.
+          That is the only editable field right now. So we disable saving for now.
+        */}
+        <Button
+          type='submit'
+          kind='primary'
+          disabled={!isNewProject || creating || updating || loading}
+        >
+          Save
         </Button>
       </div>
-      project.id
-      {project.projectId}
-    </>
+    </form>
   );
 }

--- a/packages/dashboard/src/views/ProjectEditView.tsx
+++ b/packages/dashboard/src/views/ProjectEditView.tsx
@@ -4,11 +4,19 @@ import { useGetProjectQuery, useCreateProjectMutation, useUpdateProjectMutation 
 import { Button, Icon, Tooltip, TextField, Grid, Cell } from 'bold-ui';
 import { useHistory } from "react-router-dom";
 
+type ProjectEditViewProps = {
+  match: {
+    params: {
+      projectId: string;
+    };
+  };
+};
+
 export function ProjectEditView({
   match: {
     params: { projectId },
   },
-}) {
+}:ProjectEditViewProps) {
   const history = useHistory();
   const apollo = useApolloClient();
   const isNewProject = projectId === '--create-new-project--';
@@ -18,10 +26,7 @@ export function ProjectEditView({
     },
   });
   
-  const [formState, setFormState] = useState(data?.project || {
-    projectId: isNewProject ? '' : projectId,
-    //other project fields
-  });
+
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [updating, setUpdating] = useState(false);
@@ -31,6 +36,11 @@ export function ProjectEditView({
     variables: {
       projectId: projectId
     }
+  });
+
+  const [formState, setFormState] = useState(data?.project || {
+    projectId: isNewProject ? '' : projectId,
+    //other project fields
   });
 
   const [startCreateProjectMutation] = useCreateProjectMutation({
@@ -46,6 +56,7 @@ export function ProjectEditView({
   });
 
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function updateProject() {
     setUpdating(true);
     startUpdateProjectMutation().then((result) => {

--- a/packages/dashboard/src/views/ProjectEditView.tsx
+++ b/packages/dashboard/src/views/ProjectEditView.tsx
@@ -1,9 +1,15 @@
 import { useApolloClient } from '@apollo/react-hooks';
 import React from 'react';
 import { ProjectListItem } from '../components/project/projectListItem';
-import { useGetProjectsQuery } from '../generated/graphql';
+import { useGetProjectQuery } from '../generated/graphql';
 import { Button, Icon, Text, useCss } from 'bold-ui';
-export function ProjectsView() {
+
+
+export function ProjectEditView({
+  match: {
+    params: { projectId },
+  },
+}) {
   const { css } = useCss();
   const apollo = useApolloClient();
 
@@ -13,30 +19,23 @@ export function ProjectsView() {
     },
   });
 
-  const { loading, error, data, refetch } = useGetProjectsQuery();
+  const { loading, error, data, refetch } = useGetProjectQuery({
+    variables: {
+      projectId: projectId
+    }
+  });
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>{error.toString()}</p>;
   if (!data) {
     return <p>No data</p>;
   }
-
-  const projects = data.projects;
-
-  if (!projects.length) {
-    return (
-      <div>
-        Welcome to Sorry Cypress! Your projects will appears here.{' '}
-        <a
-          href="https://github.com/agoldis/sorry-cypress"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Documentation
-        </a>
-      </div>
-    );
+  if (!data.project) {
+    return <p>Not a recognized project</p>;
   }
+
+  const project = data.project;
+
   return (
     <>
       <div className={css`
@@ -48,11 +47,8 @@ export function ProjectsView() {
           <Text color="inherit">New Project</Text>
         </Button>
       </div>
-      {projects.map((project) => (
-        <div key={project.projectId}>
-          <ProjectListItem project={project} reloadProjects={refetch}/>
-        </div>
-      ))}
+      project.id
+      {project.projectId}
     </>
   );
 }

--- a/packages/dashboard/src/views/ProjectsView.tsx
+++ b/packages/dashboard/src/views/ProjectsView.tsx
@@ -43,7 +43,10 @@ export function ProjectsView() {
         display: flex;
         flex-direction: row-reverse;
       `}>
-        <Button>
+        <Button
+          component="a"
+          href="/--create-new-project--/edit"
+        >
           <Icon style={{ marginRight: '0.5rem' }} icon="plus"/>
           <Text color="inherit">New Project</Text>
         </Button>

--- a/packages/dashboard/src/views/RunsView.tsx
+++ b/packages/dashboard/src/views/RunsView.tsx
@@ -66,9 +66,9 @@ export function RunsView({
         return {
           runFeed: {
             __typename: prev.runFeed.__typename,
-            hasMore: fetchMoreResult!.runFeed.hasMore,
-            cursor: fetchMoreResult!.runFeed.cursor,
-            runs: [...prev.runFeed.runs, ...fetchMoreResult!.runFeed.runs],
+            hasMore: fetchMoreResult?.runFeed.hasMore,
+            cursor: fetchMoreResult?.runFeed.cursor,
+            runs: [...prev.runFeed.runs, ...fetchMoreResult?.runFeed.runs],
           },
         };
       },

--- a/packages/dashboard/src/views/TestDetailsView.tsx
+++ b/packages/dashboard/src/views/TestDetailsView.tsx
@@ -37,12 +37,12 @@ export function TestDetailsView(): React.ReactNode {
       navStructure: [
         {
           __typename: 'NavStructureItem',
-          label: data.instance!.run!.meta!.projectId,
-          link: `${data.instance!.run!.meta!.projectId}/runs`,
+          label: data.instance?.run?.meta?.projectId,
+          link: `${data.instance?.run?.meta?.projectId}/runs`,
         },
         {
           __typename: 'NavStructureItem',
-          label: data.instance.run!.meta!.ciBuildId,
+          label: data.instance.run?.meta?.ciBuildId,
           link: `run/${data.instance.runId}`,
         },
         {

--- a/packages/dashboard/src/views/createProject.graphql
+++ b/packages/dashboard/src/views/createProject.graphql
@@ -1,0 +1,5 @@
+mutation createProject($project: ProjectInput) {
+  createProject(project: $project) {
+    projectId
+  }
+}

--- a/packages/dashboard/src/views/deleteProject.graphql
+++ b/packages/dashboard/src/views/deleteProject.graphql
@@ -1,0 +1,7 @@
+mutation deleteProject($projectId: ID!) {
+  deleteProject(projectId: $projectId) {
+    success
+    message
+    projectIds
+  }
+}

--- a/packages/dashboard/src/views/getProject.graphql
+++ b/packages/dashboard/src/views/getProject.graphql
@@ -1,0 +1,5 @@
+query getProject($projectId: ID!) {
+  project(id: $projectId) {
+    projectId
+  }
+}

--- a/packages/dashboard/src/views/updateProject.graphql
+++ b/packages/dashboard/src/views/updateProject.graphql
@@ -1,0 +1,5 @@
+mutation updateProject($project: ProjectInput!) {
+  updateProject(project: $project) {
+    projectId
+  }
+}


### PR DESCRIPTION
I intentionally did not handle pagination. I think we need a project wide solution. Although it will only probably be used by projects and runs right now. 🤷  @agoldis let me know what you wanna do with pagination.

So net new stuff is.
Project list page is actually not garbage. (I can say this cause I made it originally.) Its just missing pagination.
Projects can be added.
Projects can be deleted. (and cleaned up including runs and instances) It would be nice to have it clean up S3 aswell
Projects can be updated. (disabled in the UI until there is more project data to update)
Project list page UI has a new look.
Project edit page has been added.

![Screen Shot 2020-09-15 at 5 20 37 PM](https://user-images.githubusercontent.com/5297942/93275198-82748800-f779-11ea-92b2-20e50aa96ffb.png)
![Screen Shot 2020-09-15 at 5 19 20 PM](https://user-images.githubusercontent.com/5297942/93275202-830d1e80-f779-11ea-88a9-e28adaffff4d.png)

