### PR TITLE
Fix: screenshots are not shown in TestDetailsV5

### DIFF
--- a/packages/dashboard/src/components/test/TestDetails/TextDetailsV5.tsx
+++ b/packages/dashboard/src/components/test/TestDetails/TextDetailsV5.tsx
@@ -27,7 +27,7 @@ const TestAttemptView = ({
   attempt: TestAttempt;
   screenshot: Partial<InstanceScreeshot>;
 }) => {
-  const [open, toggleOpen] = useSwitch();
+  const [open, toggleOpen] = useSwitch(true);
 
   return (
     <Grid>


### PR DESCRIPTION
`useSwitch` accepts an initialising argument which defaults to `false`. [Source](https://github.com/sorry-cypress/sorry-cypress/blob/69f1eadd344cd2f5aa86c7d8634714401e6ad339/packages/dashboard/src/hooks/useSwitch.ts#L11).

To be able to display the screenshots on the Test Details we need to provide `true`.

Fixes #154.