### PR TITLE
Persist "Hide passing tests" in local storage

### DIFF
--- a/packages/dashboard/src/components/run/details.tsx
+++ b/packages/dashboard/src/components/run/details.tsx
@@ -9,9 +9,10 @@ import {
   useCss,
 } from 'bold-ui';
 import mean from 'lodash/mean';
-import React, { useState } from 'react';
+import React from 'react';
 import { generatePath } from 'react-router-dom';
 import { FullRunSpec, Run } from '../../generated/graphql';
+import { useHideSuccessfulSpecs } from '../../hooks/useHideSuccessfulSpecs';
 import { getFullRunSpecState } from '../../lib/executionState';
 import { shortEnglishHumanizerWithMsIfNeeded } from '../../lib/utis';
 import { SpecState } from '../common';
@@ -29,7 +30,7 @@ export function RunDetails({
   const { css } = useCss();
   const { specs } = run;
 
-  const [isPassedHidden, setHidePassedSpecs] = useState(false);
+  const [isPassedHidden, setHidePassedSpecs] = useHideSuccessfulSpecs();
 
   if (!specs) {
     return null;
@@ -47,6 +48,7 @@ export function RunDetails({
         <strong>Spec files</strong>
         <Switch
           label="Hide successful specs"
+          checked={isPassedHidden}
           onChange={() => setHidePassedSpecs(!isPassedHidden)}
         />
       </HFlow>

--- a/packages/dashboard/src/hooks/useHideSuccessfulSpecs.ts
+++ b/packages/dashboard/src/hooks/useHideSuccessfulSpecs.ts
@@ -1,0 +1,4 @@
+import { useLocalStorage } from './useLocalStorage';
+
+export const useHideSuccessfulSpecs = () =>
+  useLocalStorage<boolean>('shouldHideSuccessfulSpecs', false);

--- a/packages/dashboard/src/hooks/useLocalStorage.ts
+++ b/packages/dashboard/src/hooks/useLocalStorage.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 // https://usehooks.com/useLocalStorage/
-interface SetLocalStorageValue<T> {
+export interface SetLocalStorageValue<T> {
   (value: T): void;
   (value: (valueS: T) => T): void;
 }


### PR DESCRIPTION
The `Hide successful specs` switch is now persisted in local storage (single value for all projects/runs)
I also added export of the `SetLocalStorageValue` TypeScript interface, because it is the return type for `useAutoRefresh` and `useHideSuccessfulSpecs` and therefore can not be private.

Closes #139