### PR TITLE
Remove unneeded port exposure in docker-compose files

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,15 @@
+## Running the services in dev mode
+
+Starting the services with exposed ports by including the `docker-compose.dev.yml` file as following:
+
+### default
+
+`docker-compose -f docker-compose.yml -f docker-compose.dev.yml up`
+
+### minio
+
+`docker-compose -f docker-compose.minio.yml -f docker-compose.dev.yml up`
+
+### full
+
+`docker-compose -f docker-compose.full.yml -f docker-compose.dev.yml up`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+
+services:
+  mongo:
+    ports:
+      - 27017:27017
+
+  director:
+    ports:
+      - 9229:9229
+
+  api:
+    ports:
+      - 9230:9230

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -3,8 +3,6 @@ version: '3.6'
 services:
   mongo:
     image: mongo:4.0
-    ports:
-      - 27017:27017
 
   director:
     image: agoldis/sorry-cypress-director:latest

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -3,8 +3,6 @@ version: '3.6'
 services:
   mongo:
     image: mongo:4.0
-    ports:
-      - 27017:27017
 
   storage:
     image: minio/minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,12 @@ version: '3.6'
 services:
   mongo:
     image: mongo:4.0
-    ports:
-      - 27017:27017
 
   api:
     build:
       context: $PWD/packages/api
       dockerfile: Dockerfile.dev
     ports:
-      - 9230:9230
       - 4000:4000
     volumes:
       - $PWD/packages/api/src:/app/src
@@ -28,7 +25,6 @@ services:
       SCREENSHOTS_DRIVER: '../screenshots/s3.driver'
       S3_BUCKET: sorry-cypress
     ports:
-      - 9229:9229
       - 1234:1234
     volumes:
       - $PWD/packages/director/src:/app/src


### PR DESCRIPTION
Closes #190 

This PR addresses exposure of unneeded ports in docker-compose files. These files are very convenient to use but might provide a high risk when used for running on an actual server/cloud. Because the [documentation](https://sorry-cypress.dev/quickstart) only mentions running the `docker-compose.minio.yml`, I would like to make the intend more clear by adding a `docker-compose.dev.yml` that can be used on top of other docker compose files to expose extra ports.

I feel like these changes could be documented somewhere but on the other hand anyone who works on the project and needs the extra ports locally will figure it out, since this was not documented before either.

### Changes included
- `docker-compose.yml`
  - removed node debug port `9230` from `api` service
  - removed node debug port `9229` from `director` service
  - removed MongoDB connection port `27017` from `mongo` service
- `docker-compose.full.yml`
  - removed MongoDB connection port `27017` from `mongo` service
- `docker-compose.minio.yml`
  - removed MongoDB connection port `27017` from `mongo` service

### Running the services
Starting the services with exposed ports as they were before the change can be done by including the `docker-compose.dev.yml` file as following:

#### default
```bash
docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
```

#### minio
```bash
docker-compose -f docker-compose.minio.yml -f docker-compose.dev.yml up
```

#### full
```bash
docker-compose -f docker-compose.full.yml -f docker-compose.dev.yml up
```