### PR TITLE
Allow dynamic port binding for dashboard

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -37,6 +37,8 @@ services:
     image: agoldis/sorry-cypress-dashboard:${VERSION:-latest}
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      PORT: 8080
+      CI_URL: ''
     ports:
       - 8080:8080
     depends_on:

--- a/docker-compose.cos.yml
+++ b/docker-compose.cos.yml
@@ -35,6 +35,8 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      PORT: 8080
+      CI_URL: ''
     ports:
       - 8080:8080
     depends_on:

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -34,6 +34,8 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      CI_URL: ''
+      PORT: 8080
     ports:
       - 8080:8080
     depends_on:

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -67,6 +67,8 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      PORT: 8080
+      CI_URL: ''
     ports:
       - 8080:8080
     depends_on:

--- a/kubernetes-cos.yml
+++ b/kubernetes-cos.yml
@@ -23,38 +23,38 @@ spec:
   template:
     metadata:
       name: mongo
-      labels: 
+      labels:
         app: mongo
     spec:
       containers:
-      - image: mongo:4.0
-        imagePullPolicy: "Always"
-        name: mongo
-        ports:
-        - containerPort: 27017
-        readinessProbe:
-          exec:
-            command:
-            - mongo
-            - --eval
-            - db.adminCommand('ping')
-          failureThreshold: 6
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
-        volumeMounts:
-          - name: mongo-storage
-            mountPath: /data/db
+        - image: mongo:4.0
+          imagePullPolicy: 'Always'
+          name: mongo
+          ports:
+            - containerPort: 27017
+          readinessProbe:
+            exec:
+              command:
+                - mongo
+                - --eval
+                - db.adminCommand('ping')
+            failureThreshold: 6
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
+          volumeMounts:
+            - name: mongo-storage
+              mountPath: /data/db
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes:
         - name: mongo-storage
           persistentVolumeClaim:
@@ -77,25 +77,25 @@ spec:
       name: api
     spec:
       containers:
-      - env:
-        - name: MONGODB_DATABASE
-          value: sorry-cypress
-        - name: MONGODB_URI
-          value: mongodb://mongo-service:27017
-        image: agoldis/sorry-cypress-api:latest
-        imagePullPolicy: "Always"
-        name: api
-        ports:
-        - containerPort: 4000
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: MONGODB_DATABASE
+              value: sorry-cypress
+            - name: MONGODB_URI
+              value: mongodb://mongo-service:27017
+          image: agoldis/sorry-cypress-api:latest
+          imagePullPolicy: 'Always'
+          name: api
+          ports:
+            - containerPort: 4000
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: apps/v1
@@ -114,53 +114,53 @@ spec:
       name: director
     spec:
       containers:
-      - env:
-        - name: DASHBOARD_URL
-          value: [YOUR-DASHBOARD-URL-HERE]
-        - name: EXECUTION_DRIVER
-          value: ../execution/mongo/driver
-        - name: MONGODB_DATABASE
-          value: sorry-cypress
-        - name: MONGODB_URI
-          value: mongodb://mongo-service:27017
-        - name: SCREENSHOTS_DRIVER
-          value: ../screenshots/cos.driver
-        - name: COS_BUCKET
-          value: sorry-cypress-test
-        - name: COS_REGION
-          value: us-south
-        - name: COS_ACCESSKEY
-          valueFrom:
-              secretKeyRef:
-                name: cypress-cos-secrets
-                key: COS_ACCESSKEY
-        - name: COS_SECRETKEY
-          valueFrom:
-              secretKeyRef:
-                name: cypress-cos-secrets
-                key: COS_SECRETKEY
-        image: juanjosepb/sorry-cypress-director:v0.1
-        imagePullPolicy: "Always"
-        name: director
-        ports:
-        - containerPort: 1234
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 1234
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 2
-          failureThreshold: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: DASHBOARD_URL
+              value: [YOUR-DASHBOARD-URL-HERE]
+            - name: EXECUTION_DRIVER
+              value: ../execution/mongo/driver
+            - name: MONGODB_DATABASE
+              value: sorry-cypress
+            - name: MONGODB_URI
+              value: mongodb://mongo-service:27017
+            - name: SCREENSHOTS_DRIVER
+              value: ../screenshots/cos.driver
+            - name: COS_BUCKET
+              value: sorry-cypress-test
+            - name: COS_REGION
+              value: us-south
+            - name: COS_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: cypress-cos-secrets
+                  key: COS_ACCESSKEY
+            - name: COS_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: cypress-cos-secrets
+                  key: COS_SECRETKEY
+          image: juanjosepb/sorry-cypress-director:v0.1
+          imagePullPolicy: 'Always'
+          name: director
+          ports:
+            - containerPort: 1234
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 1234
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 2
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: apps/v1
@@ -179,31 +179,35 @@ spec:
       name: dashboard
     spec:
       containers:
-      - env:
-        - name: GRAPHQL_SCHEMA_URL
-          value: [YOUR-API-URL-HERE]
-        image: agoldis/sorry-cypress-dashboard:latest
-        imagePullPolicy: "Always"
-        name: dashboard
-        ports:
-        - containerPort: 8080
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 2
-          failureThreshold: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: GRAPHQL_SCHEMA_URL
+              value: [YOUR-API-URL-HERE]
+            - name: PORT
+              value: 8080
+            - name: CI_URL
+              value: ''
+          image: agoldis/sorry-cypress-dashboard:latest
+          imagePullPolicy: 'Always'
+          name: dashboard
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 2
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: v1
@@ -212,9 +216,9 @@ metadata:
   name: dashboard-service
 spec:
   ports:
-  - name: "8080"
-    port: 8080
-    targetPort: 8080
+    - name: '8080'
+      port: 8080
+      targetPort: 8080
   selector:
     app: dashboard
 ---
@@ -224,9 +228,9 @@ metadata:
   name: api-service
 spec:
   ports:
-  - name: "4000"
-    port: 4000
-    targetPort: 4000
+    - name: '4000'
+      port: 4000
+      targetPort: 4000
   selector:
     app: api
 ---
@@ -236,9 +240,9 @@ metadata:
   name: mongo-service
 spec:
   ports:
-  - name: "27017"
-    port: 27017
-    targetPort: 27017
+    - name: '27017'
+      port: 27017
+      targetPort: 27017
   selector:
     app: mongo
 ---
@@ -248,9 +252,9 @@ metadata:
   name: director-service
 spec:
   ports:
-  - name: "1234"
-    port: 1234
-    targetPort: 1234
+    - name: '1234'
+      port: 1234
+      targetPort: 1234
   selector:
     app: director
 ---
@@ -270,21 +274,21 @@ metadata:
   name: cypress-ingresses
 spec:
   rules:
-  - host: [YOUR-DASHBOARD-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: dashboard-service
-          servicePort: 8080
-  - host: [YOUR-API-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: api-service
-          servicePort: 4000
-  - host: [YOUR-DIRECTOR-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: director-service
-          servicePort: 1234
+    - host: [YOUR-DASHBOARD-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: dashboard-service
+              servicePort: 8080
+    - host: [YOUR-API-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: api-service
+              servicePort: 4000
+    - host: [YOUR-DIRECTOR-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: director-service
+              servicePort: 1234

--- a/kubernetes-full.yml
+++ b/kubernetes-full.yml
@@ -23,38 +23,38 @@ spec:
   template:
     metadata:
       name: mongo
-      labels: 
+      labels:
         app: mongo
     spec:
       containers:
-      - image: mongo:4.0
-        imagePullPolicy: "Always"
-        name: mongo
-        ports:
-        - containerPort: 27017
-        readinessProbe:
-          exec:
-            command:
-            - mongo
-            - --eval
-            - db.adminCommand('ping')
-          failureThreshold: 6
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
-        volumeMounts:
-          - name: mongo-storage
-            mountPath: /data/db
+        - image: mongo:4.0
+          imagePullPolicy: 'Always'
+          name: mongo
+          ports:
+            - containerPort: 27017
+          readinessProbe:
+            exec:
+              command:
+                - mongo
+                - --eval
+                - db.adminCommand('ping')
+            failureThreshold: 6
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
+          volumeMounts:
+            - name: mongo-storage
+              mountPath: /data/db
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes:
         - name: mongo-storage
           persistentVolumeClaim:
@@ -77,25 +77,25 @@ spec:
       name: api
     spec:
       containers:
-      - env:
-        - name: MONGODB_DATABASE
-          value: sorry-cypress
-        - name: MONGODB_URI
-          value: mongodb://mongo-service:27017
-        image: agoldis/sorry-cypress-api:latest
-        imagePullPolicy: "Always"
-        name: api
-        ports:
-        - containerPort: 4000
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: MONGODB_DATABASE
+              value: sorry-cypress
+            - name: MONGODB_URI
+              value: mongodb://mongo-service:27017
+          image: agoldis/sorry-cypress-api:latest
+          imagePullPolicy: 'Always'
+          name: api
+          ports:
+            - containerPort: 4000
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: apps/v1
@@ -114,53 +114,53 @@ spec:
       name: director
     spec:
       containers:
-      - env:
-        - name: DASHBOARD_URL
-          value: [YOUR-DASHBOARD-URL-HERE]
-        - name: EXECUTION_DRIVER
-          value: ../execution/mongo/driver
-        - name: MONGODB_DATABASE
-          value: sorry-cypress
-        - name: MONGODB_URI
-          value: mongodb://mongo-service:27017
-        - name: SCREENSHOTS_DRIVER
-          value: ../screenshots/s3.driver
-        - name: S3_BUCKET
-          value: [bucket-name]
-        - name: S3_REGION
-          value: us-east-1
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-              secretKeyRef:
-                name: cypress-s3-secrets
-                key: AWS_ACCESS_KEY_ID
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-              secretKeyRef:
-                name: cypress-s3-secrets
-                key: AWS_SECRET_ACCESS_KEY
-        image: agoldis/sorry-cypress-director:latest
-        imagePullPolicy: "Always"
-        name: director
-        ports:
-        - containerPort: 1234
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 1234
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 2
-          failureThreshold: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: DASHBOARD_URL
+              value: [YOUR-DASHBOARD-URL-HERE]
+            - name: EXECUTION_DRIVER
+              value: ../execution/mongo/driver
+            - name: MONGODB_DATABASE
+              value: sorry-cypress
+            - name: MONGODB_URI
+              value: mongodb://mongo-service:27017
+            - name: SCREENSHOTS_DRIVER
+              value: ../screenshots/s3.driver
+            - name: S3_BUCKET
+              value: [bucket-name]
+            - name: S3_REGION
+              value: us-east-1
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cypress-s3-secrets
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cypress-s3-secrets
+                  key: AWS_SECRET_ACCESS_KEY
+          image: agoldis/sorry-cypress-director:latest
+          imagePullPolicy: 'Always'
+          name: director
+          ports:
+            - containerPort: 1234
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 1234
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 2
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: apps/v1
@@ -179,31 +179,35 @@ spec:
       name: dashboard
     spec:
       containers:
-      - env:
-        - name: GRAPHQL_SCHEMA_URL
-          value: [YOUR-API-URL-HERE]
-        image: agoldis/sorry-cypress-dashboard:latest
-        imagePullPolicy: "Always"
-        name: dashboard
-        ports:
-        - containerPort: 8080
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 2
-          failureThreshold: 5
-        resources:
-          requests:
-            memory: "128M"
-            cpu: 0.2
-          limits:
-            memory: "512M"
-            cpu: 0.5
+        - env:
+            - name: GRAPHQL_SCHEMA_URL
+              value: [YOUR-API-URL-HERE]
+            - name: PORT
+              value: 8080
+            - name: CI_URL
+              value: ''
+          image: agoldis/sorry-cypress-dashboard:latest
+          imagePullPolicy: 'Always'
+          name: dashboard
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 2
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: '128M'
+              cpu: 0.2
+            limits:
+              memory: '512M'
+              cpu: 0.5
       restartPolicy: Always
-      serviceAccountName: ""
+      serviceAccountName: ''
       volumes: null
 ---
 apiVersion: v1
@@ -212,9 +216,9 @@ metadata:
   name: dashboard-service
 spec:
   ports:
-  - name: "8080"
-    port: 8080
-    targetPort: 8080
+    - name: '8080'
+      port: 8080
+      targetPort: 8080
   selector:
     app: dashboard
 ---
@@ -224,9 +228,9 @@ metadata:
   name: api-service
 spec:
   ports:
-  - name: "4000"
-    port: 4000
-    targetPort: 4000
+    - name: '4000'
+      port: 4000
+      targetPort: 4000
   selector:
     app: api
 ---
@@ -236,9 +240,9 @@ metadata:
   name: mongo-service
 spec:
   ports:
-  - name: "27017"
-    port: 27017
-    targetPort: 27017
+    - name: '27017'
+      port: 27017
+      targetPort: 27017
   selector:
     app: mongo
 ---
@@ -248,9 +252,9 @@ metadata:
   name: director-service
 spec:
   ports:
-  - name: "1234"
-    port: 1234
-    targetPort: 1234
+    - name: '1234'
+      port: 1234
+      targetPort: 1234
   selector:
     app: director
 ---
@@ -260,24 +264,24 @@ metadata:
   name: cypress-ingresses
 spec:
   rules:
-  - host: [YOUR-DASHBOARD-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: dashboard-service
-          servicePort: 8080
-  - host: [YOUR-API-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: api-service
-          servicePort: 4000
-  - host: [YOUR-DIRECTOR-URL-HERE]
-    http:
-      paths:
-      - backend:
-          serviceName: director-service
-          servicePort: 1234
+    - host: [YOUR-DASHBOARD-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: dashboard-service
+              servicePort: 8080
+    - host: [YOUR-API-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: api-service
+              servicePort: 4000
+    - host: [YOUR-DIRECTOR-URL-HERE]
+      http:
+        paths:
+          - backend:
+              serviceName: director-service
+              servicePort: 1234
 ---
 apiVersion: v1
 kind: Secret

--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -6,10 +6,8 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1-alpine
-ENV NGINX_ENVSUBST_TEMPLATE_DIR=/usr/share/nginx/html
-ENV NGINX_ENVSUBST_OUTPUT_DIR=/usr/share/nginx/html
 WORKDIR /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 COPY /server/static .
 COPY --from=build /app/dist .
-RUN sed 's/<?- SORRY_CYPRESS_ENVIRONMENT ?>/{"GRAPHQL_SCHEMA_URL":"$GRAPHQL_SCHEMA_URL","CI_URL":"$CI_URL"}/' views/index.ejs > index.html.template
+COPY --from=build /app/dist/views/index.ejs index.html

--- a/packages/dashboard/nginx.conf
+++ b/packages/dashboard/nginx.conf
@@ -1,5 +1,0 @@
-server {
-	listen 8080;
-	root /usr/share/nginx/html;
-	try_files $uri /index.html;
-}

--- a/packages/dashboard/nginx/default.conf.template
+++ b/packages/dashboard/nginx/default.conf.template
@@ -1,0 +1,7 @@
+server {
+	listen ${PORT} default_server;
+	root /usr/share/nginx/html;
+	try_files $uri /index.html;
+	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
+	sub_filter_once on;
+}

--- a/packages/dashboard/src/state/environment.ts
+++ b/packages/dashboard/src/state/environment.ts
@@ -3,7 +3,10 @@ export interface Environment {
   CI_URL: string;
 }
 
-export const environment: Environment = (window.__sorryCypressEnvironment as Environment) || {
-  GRAPHQL_SCHEMA_URL: 'http://localhost:4000',
-  CI_URL: '',
+export const environment: Environment = {
+  ...{
+    GRAPHQL_SCHEMA_URL: 'http://localhost:4000',
+    CI_URL: '',
+  },
+  ...((window.__sorryCypressEnvironment as Environment) || {}),
 };


### PR DESCRIPTION
Allows dynamic port binding for dashboard via `PORT` env var. Hardcoded `8080` would not allow running on heroku, and, in general, should not be hardcoded. 

It is a follow up on @slinstaedt work in #230, which was awesome because it reduced image size significantly (and caused me to explore multi-staged Dockerfiles).

 @tico24
One less-desired side effect is that dashboard environment variables are now mandatory to run production. I have updated kubernetes templates accordingly. I guess we also need to update helm charts? 

