### PR TITLE
Add support to ApolloClient credentials in the dashboard

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -37,6 +37,7 @@ services:
     image: agoldis/sorry-cypress-dashboard:${VERSION:-latest}
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      GRAPHQL_CLIENT_CREDENTIALS: ''
       PORT: 8080
       CI_URL: ''
     ports:

--- a/docker-compose.cos.yml
+++ b/docker-compose.cos.yml
@@ -35,6 +35,7 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      GRAPHQL_CLIENT_CREDENTIALS: ''
       PORT: 8080
       CI_URL: ''
     ports:

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -34,6 +34,7 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      GRAPHQL_CLIENT_CREDENTIALS: ''
       CI_URL: ''
       PORT: 8080
     ports:

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -67,6 +67,7 @@ services:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
       GRAPHQL_SCHEMA_URL: http://localhost:4000
+      GRAPHQL_CLIENT_CREDENTIALS: ''
       PORT: 8080
       CI_URL: ''
     ports:

--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -11,3 +11,6 @@ COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 COPY /server/static .
 COPY --from=build /app/dist .
 COPY --from=build /app/dist/views/index.ejs index.html
+ENV GRAPHQL_SCHEMA_URL "http://localhost:4000"
+ENV CI_URL ""
+ENV GRAPHQL_CLIENT_CREDENTIALS ""

--- a/packages/dashboard/nginx/default.conf.template
+++ b/packages/dashboard/nginx/default.conf.template
@@ -2,6 +2,6 @@ server {
 	listen ${PORT} default_server;
 	root /usr/share/nginx/html;
 	try_files $uri /index.html;
-	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_CLIENT_ATTRIBUTES: "${GRAPHQL_CLIENT_ATTRIBUTES}", GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
+	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_CLIENT_CREDENTIALS: "${GRAPHQL_CLIENT_CREDENTIALS}", GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
 	sub_filter_once on;
 }

--- a/packages/dashboard/nginx/default.conf.template
+++ b/packages/dashboard/nginx/default.conf.template
@@ -2,6 +2,6 @@ server {
 	listen ${PORT} default_server;
 	root /usr/share/nginx/html;
 	try_files $uri /index.html;
-	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
+	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_CLIENT_ATTRIBUTES: "${GRAPHQL_CLIENT_ATTRIBUTES}", GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
 	sub_filter_once on;
 }

--- a/packages/dashboard/server/app.js
+++ b/packages/dashboard/server/app.js
@@ -1,9 +1,14 @@
 const express = require('express');
 const path = require('path');
 const app = (exports.app = express());
-const { GRAPHQL_SCHEMA_URL, CI_URL } = require('./config');
+const {
+  GRAPHQL_CLIENT_CREDENTIALS,
+  GRAPHQL_SCHEMA_URL,
+  CI_URL,
+} = require('./config');
 
 const SORRY_CYPRESS_ENVIRONMENT = JSON.stringify({
+  GRAPHQL_CLIENT_CREDENTIALS,
   GRAPHQL_SCHEMA_URL,
   CI_URL,
 });

--- a/packages/dashboard/server/config.js
+++ b/packages/dashboard/server/config.js
@@ -3,4 +3,6 @@ require('dotenv').config();
 exports.PORT = process.env.PORT || 8080;
 exports.GRAPHQL_SCHEMA_URL =
   process.env.GRAPHQL_SCHEMA_URL || 'http://localhost:4000';
+exports.GRAPHQL_CLIENT_CREDENTIALS =
+  process.env.GRAPHQL_CLIENT_CREDENTIALS || undefined;
 exports.CI_URL = process.env.CI_URL || '';

--- a/packages/dashboard/server/config.js
+++ b/packages/dashboard/server/config.js
@@ -4,5 +4,5 @@ exports.PORT = process.env.PORT || 8080;
 exports.GRAPHQL_SCHEMA_URL =
   process.env.GRAPHQL_SCHEMA_URL || 'http://localhost:4000';
 exports.GRAPHQL_CLIENT_CREDENTIALS =
-  process.env.GRAPHQL_CLIENT_CREDENTIALS || undefined;
+  process.env.GRAPHQL_CLIENT_CREDENTIALS || '';
 exports.CI_URL = process.env.CI_URL || '';

--- a/packages/dashboard/src/config.ts
+++ b/packages/dashboard/src/config.ts
@@ -1,4 +1,4 @@
 import 'dotenv/config';
 
-export const API_CLIENT_CREDENTIALS =
-  process.env.API_CLIENT_CREDENTIALS || undefined;
+export const GRAPHQL_CLIENT_CREDENTIALS =
+  process.env.GRAPHQL_CLIENT_CREDENTIALS || undefined;

--- a/packages/dashboard/src/config.ts
+++ b/packages/dashboard/src/config.ts
@@ -1,0 +1,4 @@
+import 'dotenv/config';
+
+export const API_CLIENT_CREDENTIALS =
+  process.env.API_CLIENT_CREDENTIALS || undefined;

--- a/packages/dashboard/src/config.ts
+++ b/packages/dashboard/src/config.ts
@@ -1,4 +1,0 @@
-import 'dotenv/config';
-
-export const GRAPHQL_CLIENT_CREDENTIALS =
-  process.env.GRAPHQL_CLIENT_CREDENTIALS || undefined;

--- a/packages/dashboard/src/lib/apolloClient.ts
+++ b/packages/dashboard/src/lib/apolloClient.ts
@@ -1,6 +1,7 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
 import { environment } from '../state/environment';
 import { navStructure } from './navigation';
+import { API_CLIENT_CREDENTIALS } from '@src/config';
 
 const cache = new InMemoryCache({
   typePolicies: {
@@ -27,6 +28,7 @@ export const client = new ApolloClient({
   cache,
   link,
   resolvers: {},
+  credentials: API_CLIENT_CREDENTIALS,
 });
 
 client.onResetStore(async () => navStructure([]));

--- a/packages/dashboard/src/lib/apolloClient.ts
+++ b/packages/dashboard/src/lib/apolloClient.ts
@@ -1,7 +1,6 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
 import { environment } from '../state/environment';
 import { navStructure } from './navigation';
-import { GRAPHQL_CLIENT_CREDENTIALS } from '@src/config';
 
 const cache = new InMemoryCache({
   typePolicies: {
@@ -22,7 +21,7 @@ const cache = new InMemoryCache({
 
 const link = createHttpLink({
   uri: environment.GRAPHQL_SCHEMA_URL,
-  credentials: GRAPHQL_CLIENT_CREDENTIALS,
+  credentials: environment.GRAPHQL_CLIENT_CREDENTIALS,
 });
 
 export const client = new ApolloClient({

--- a/packages/dashboard/src/lib/apolloClient.ts
+++ b/packages/dashboard/src/lib/apolloClient.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
 import { environment } from '../state/environment';
 import { navStructure } from './navigation';
-import { API_CLIENT_CREDENTIALS } from '@src/config';
+import { GRAPHQL_CLIENT_CREDENTIALS } from '@src/config';
 
 const cache = new InMemoryCache({
   typePolicies: {
@@ -22,13 +22,13 @@ const cache = new InMemoryCache({
 
 const link = createHttpLink({
   uri: environment.GRAPHQL_SCHEMA_URL,
+  credentials: GRAPHQL_CLIENT_CREDENTIALS,
 });
 
 export const client = new ApolloClient({
   cache,
   link,
   resolvers: {},
-  credentials: API_CLIENT_CREDENTIALS,
 });
 
 client.onResetStore(async () => navStructure([]));

--- a/packages/dashboard/src/lib/apolloClient.ts
+++ b/packages/dashboard/src/lib/apolloClient.ts
@@ -21,7 +21,7 @@ const cache = new InMemoryCache({
 
 const link = createHttpLink({
   uri: environment.GRAPHQL_SCHEMA_URL,
-  credentials: environment.GRAPHQL_CLIENT_CREDENTIALS,
+  credentials: environment.GRAPHQL_CLIENT_CREDENTIALS || undefined,
 });
 
 export const client = new ApolloClient({

--- a/packages/dashboard/src/state/environment.ts
+++ b/packages/dashboard/src/state/environment.ts
@@ -1,10 +1,12 @@
 export interface Environment {
+  GRAPHQL_CLIENT_CREDENTIALS: string;
   GRAPHQL_SCHEMA_URL: string;
   CI_URL: string;
 }
 
 export const environment: Environment = {
   ...{
+    GRAPHQL_CLIENT_CREDENTIALS: undefined,
     GRAPHQL_SCHEMA_URL: 'http://localhost:4000',
     CI_URL: '',
   },

--- a/packages/dashboard/src/state/environment.ts
+++ b/packages/dashboard/src/state/environment.ts
@@ -6,7 +6,7 @@ export interface Environment {
 
 export const environment: Environment = {
   ...{
-    GRAPHQL_CLIENT_CREDENTIALS: undefined,
+    GRAPHQL_CLIENT_CREDENTIALS: '',
     GRAPHQL_SCHEMA_URL: 'http://localhost:4000',
     CI_URL: '',
   },


### PR DESCRIPTION
This PR adds a `GRAPHQL_CLIENT_CREDENTIALS` to allow configuring [GraphQL's authentication](https://www.apollographql.com/docs/react/networking/authentication/#cookie) when the apollo client (`GRAPHQL_SCHEMA_URL`) is external.

**Note: if the environment variables are not set, there aren't any behavior changes.**