### PR TITLE
Add slack hook filters and advanced formatting

### DIFF
--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -12,7 +12,7 @@ export type Scalars = {
   Float: number;
   GenericHookType: any;
   SlackHookType: any;
-  SlackEventFilter: any;
+  SlackResultFilter: any;
   GithubHookType: any;
   BitbucketHookType: any;
   DateTime: any;
@@ -201,13 +201,13 @@ export type SlackHook = {
   url: Scalars['String'];
   hookType: Scalars['SlackHookType'];
   hookEvents: Array<Scalars['String']>;
-  slackEventFilter: Scalars['SlackEventFilter'];
+  slackResultFilter: Scalars['SlackResultFilter'];
   slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateSlackHookInput = {
   projectId: Scalars['ID'];
-  slackEventFilter?: Maybe<Scalars['SlackEventFilter']>;
+  slackResultFilter?: Maybe<Scalars['SlackResultFilter']>;
 };
 
 export type UpdateSlackHookInput = {
@@ -215,7 +215,7 @@ export type UpdateSlackHookInput = {
   hookId: Scalars['ID'];
   url: Scalars['String'];
   hookEvents: Array<Scalars['String']>;
-  slackEventFilter: Scalars['SlackEventFilter'];
+  slackResultFilter: Scalars['SlackResultFilter'];
   slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -299,7 +299,7 @@ export type Hook = {
   bitbucketUsername?: Maybe<Scalars['String']>;
   bitbucketToken?: Maybe<Scalars['String']>;
   bitbucketBuildName?: Maybe<Scalars['String']>;
-  slackEventFilter?: Maybe<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['String']>;
   slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -321,7 +321,7 @@ export type HookInput = {
   bitbucketUsername?: Maybe<Scalars['String']>;
   bitbucketToken?: Maybe<Scalars['String']>;
   bitbucketBuildName?: Maybe<Scalars['String']>;
-  slackEventFilter?: Maybe<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['String']>;
   slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -625,7 +625,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']>;
   GenericHookType: ResolverTypeWrapper<Scalars['GenericHookType']>;
   SlackHookType: ResolverTypeWrapper<Scalars['SlackHookType']>;
-  SlackEventFilter: ResolverTypeWrapper<Scalars['SlackEventFilter']>;
+  SlackResultFilter: ResolverTypeWrapper<Scalars['SlackResultFilter']>;
   GithubHookType: ResolverTypeWrapper<Scalars['GithubHookType']>;
   BitbucketHookType: ResolverTypeWrapper<Scalars['BitbucketHookType']>;
   DeleteHookInput: DeleteHookInput;
@@ -686,7 +686,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'];
   GenericHookType: Scalars['GenericHookType'];
   SlackHookType: Scalars['SlackHookType'];
-  SlackEventFilter: Scalars['SlackEventFilter'];
+  SlackResultFilter: Scalars['SlackResultFilter'];
   GithubHookType: Scalars['GithubHookType'];
   BitbucketHookType: Scalars['BitbucketHookType'];
   DeleteHookInput: DeleteHookInput;
@@ -783,8 +783,8 @@ export interface SlackHookTypeScalarConfig extends GraphQLScalarTypeConfig<Resol
   name: 'SlackHookType';
 }
 
-export interface SlackEventFilterScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackEventFilter'], any> {
-  name: 'SlackEventFilter';
+export interface SlackResultFilterScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackResultFilter'], any> {
+  name: 'SlackResultFilter';
 }
 
 export interface GithubHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
@@ -807,7 +807,7 @@ export type SlackHookResolvers<ContextType = any, ParentType extends ResolversPa
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hookType?: Resolver<ResolversTypes['SlackHookType'], ParentType, ContextType>;
   hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  slackEventFilter?: Resolver<ResolversTypes['SlackEventFilter'], ParentType, ContextType>;
+  slackResultFilter?: Resolver<ResolversTypes['SlackResultFilter'], ParentType, ContextType>;
   slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
@@ -854,7 +854,7 @@ export type HookResolvers<ContextType = any, ParentType extends ResolversParentT
   bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  slackEventFilter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  slackResultFilter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
@@ -1056,7 +1056,7 @@ export type Resolvers<ContextType = any> = {
   SpecStats?: SpecStatsResolvers<ContextType>;
   GenericHookType?: GraphQLScalarType;
   SlackHookType?: GraphQLScalarType;
-  SlackEventFilter?: GraphQLScalarType;
+  SlackResultFilter?: GraphQLScalarType;
   GithubHookType?: GraphQLScalarType;
   BitbucketHookType?: GraphQLScalarType;
   DeleteHookResponse?: DeleteHookResponseResolvers<ContextType>;

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -12,6 +12,7 @@ export type Scalars = {
   Float: number;
   GenericHookType: any;
   SlackHookType: any;
+  SlackEventFilter: any;
   GithubHookType: any;
   BitbucketHookType: any;
   DateTime: any;
@@ -181,6 +182,7 @@ export type SpecStats = {
 
 
 
+
 export type DeleteHookInput = {
   projectId: Scalars['ID'];
   hookId: Scalars['ID'];
@@ -199,10 +201,13 @@ export type SlackHook = {
   url: Scalars['String'];
   hookType: Scalars['SlackHookType'];
   hookEvents: Array<Scalars['String']>;
+  slackEventFilter: Scalars['SlackEventFilter'];
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateSlackHookInput = {
   projectId: Scalars['ID'];
+  slackEventFilter?: Maybe<Scalars['SlackEventFilter']>;
 };
 
 export type UpdateSlackHookInput = {
@@ -210,6 +215,8 @@ export type UpdateSlackHookInput = {
   hookId: Scalars['ID'];
   url: Scalars['String'];
   hookEvents: Array<Scalars['String']>;
+  slackEventFilter: Scalars['SlackEventFilter'];
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type GithubHook = {
@@ -292,6 +299,8 @@ export type Hook = {
   bitbucketUsername?: Maybe<Scalars['String']>;
   bitbucketToken?: Maybe<Scalars['String']>;
   bitbucketBuildName?: Maybe<Scalars['String']>;
+  slackEventFilter?: Maybe<Scalars['String']>;
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type Project = {
@@ -312,6 +321,8 @@ export type HookInput = {
   bitbucketUsername?: Maybe<Scalars['String']>;
   bitbucketToken?: Maybe<Scalars['String']>;
   bitbucketBuildName?: Maybe<Scalars['String']>;
+  slackEventFilter?: Maybe<Scalars['String']>;
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateProjectInput = {
@@ -614,6 +625,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']>;
   GenericHookType: ResolverTypeWrapper<Scalars['GenericHookType']>;
   SlackHookType: ResolverTypeWrapper<Scalars['SlackHookType']>;
+  SlackEventFilter: ResolverTypeWrapper<Scalars['SlackEventFilter']>;
   GithubHookType: ResolverTypeWrapper<Scalars['GithubHookType']>;
   BitbucketHookType: ResolverTypeWrapper<Scalars['BitbucketHookType']>;
   DeleteHookInput: DeleteHookInput;
@@ -674,6 +686,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'];
   GenericHookType: Scalars['GenericHookType'];
   SlackHookType: Scalars['SlackHookType'];
+  SlackEventFilter: Scalars['SlackEventFilter'];
   GithubHookType: Scalars['GithubHookType'];
   BitbucketHookType: Scalars['BitbucketHookType'];
   DeleteHookInput: DeleteHookInput;
@@ -770,6 +783,10 @@ export interface SlackHookTypeScalarConfig extends GraphQLScalarTypeConfig<Resol
   name: 'SlackHookType';
 }
 
+export interface SlackEventFilterScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackEventFilter'], any> {
+  name: 'SlackEventFilter';
+}
+
 export interface GithubHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
   name: 'GithubHookType';
 }
@@ -790,6 +807,8 @@ export type SlackHookResolvers<ContextType = any, ParentType extends ResolversPa
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hookType?: Resolver<ResolversTypes['SlackHookType'], ParentType, ContextType>;
   hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  slackEventFilter?: Resolver<ResolversTypes['SlackEventFilter'], ParentType, ContextType>;
+  slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -835,6 +854,8 @@ export type HookResolvers<ContextType = any, ParentType extends ResolversParentT
   bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  slackEventFilter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -1035,6 +1056,7 @@ export type Resolvers<ContextType = any> = {
   SpecStats?: SpecStatsResolvers<ContextType>;
   GenericHookType?: GraphQLScalarType;
   SlackHookType?: GraphQLScalarType;
+  SlackEventFilter?: GraphQLScalarType;
   GithubHookType?: GraphQLScalarType;
   BitbucketHookType?: GraphQLScalarType;
   DeleteHookResponse?: DeleteHookResponseResolvers<ContextType>;

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -55,7 +55,7 @@ type SpecStats {
 
 scalar GenericHookType
 scalar SlackHookType
-scalar SlackEventFilter
+scalar SlackResultFilter
 scalar GithubHookType
 scalar BitbucketHookType
 
@@ -74,13 +74,13 @@ type SlackHook {
   url: String!
   hookType: SlackHookType!
   hookEvents: [String!]!
-  slackEventFilter: SlackEventFilter!
+  slackResultFilter: SlackResultFilter!
   slackBranchFilter: [String]
 }
 
 input CreateSlackHookInput {
   projectId: ID!
-  slackEventFilter: SlackEventFilter = "ALL"
+  slackResultFilter: SlackResultFilter = "ALL"
 }
 
 input UpdateSlackHookInput {
@@ -88,7 +88,7 @@ input UpdateSlackHookInput {
   hookId: ID!
   url: String!
   hookEvents: [String!]!
-  slackEventFilter: SlackEventFilter!
+  slackResultFilter: SlackResultFilter!
   slackBranchFilter: [String]
 }
 
@@ -168,7 +168,7 @@ type Hook {
   bitbucketUsername: String
   bitbucketToken: String
   bitbucketBuildName: String
-  slackEventFilter: String
+  slackResultFilter: String
   slackBranchFilter: [String]
 }
 
@@ -189,7 +189,7 @@ input HookInput {
   bitbucketUsername: String
   bitbucketToken: String
   bitbucketBuildName: String
-  slackEventFilter: String
+  slackResultFilter: String
   slackBranchFilter: [String]
 }
 

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -55,6 +55,7 @@ type SpecStats {
 
 scalar GenericHookType
 scalar SlackHookType
+scalar SlackEventFilter
 scalar GithubHookType
 scalar BitbucketHookType
 
@@ -73,10 +74,13 @@ type SlackHook {
   url: String!
   hookType: SlackHookType!
   hookEvents: [String!]!
+  slackEventFilter: SlackEventFilter!
+  slackBranchFilter: [String]
 }
 
 input CreateSlackHookInput {
   projectId: ID!
+  slackEventFilter: SlackEventFilter = "ALL"
 }
 
 input UpdateSlackHookInput {
@@ -84,6 +88,8 @@ input UpdateSlackHookInput {
   hookId: ID!
   url: String!
   hookEvents: [String!]!
+  slackEventFilter: SlackEventFilter!
+  slackBranchFilter: [String]
 }
 
 type GithubHook {
@@ -162,6 +168,8 @@ type Hook {
   bitbucketUsername: String
   bitbucketToken: String
   bitbucketBuildName: String
+  slackEventFilter: String
+  slackBranchFilter: [String]
 }
 
 type Project {
@@ -181,6 +189,8 @@ input HookInput {
   bitbucketUsername: String
   bitbucketToken: String
   bitbucketBuildName: String
+  slackEventFilter: String
+  slackBranchFilter: [String]
 }
 
 input CreateProjectInput {

--- a/packages/common/src/hook/types.ts
+++ b/packages/common/src/hook/types.ts
@@ -16,7 +16,7 @@ export enum HookEvent {
   INSTANCE_FINISH = 'INSTANCE_FINISH',
 }
 
-export enum EventFilter {
+export enum ResultFilter {
   ALL = 'ALL',
   ONLY_FAILED = 'ONLY_FAILED',
   ONLY_SUCCESSFUL = 'ONLY_SUCCESSFUL',
@@ -31,7 +31,7 @@ export type SlackHook = BaseHook & {
   username?: string;
   hookEvents: HookEvent[];
   hookType: HookType.SLACK_HOOK;
-  slackEventFilter: EventFilter;
+  slackResultFilter: ResultFilter;
   slackBranchFilter?: string[];
 };
 

--- a/packages/common/src/hook/types.ts
+++ b/packages/common/src/hook/types.ts
@@ -16,15 +16,25 @@ export enum HookEvent {
   INSTANCE_FINISH = 'INSTANCE_FINISH',
 }
 
+export enum EventFilter {
+  ALL = 'ALL',
+  ONLY_FAILED = 'ONLY_FAILED',
+  ONLY_SUCCESSFUL = 'ONLY_SUCCESSFUL',
+}
+
 type BaseHook = {
   hookId: string;
   url: string;
 };
+
 export type SlackHook = BaseHook & {
   username?: string;
   hookEvents: HookEvent[];
   hookType: HookType.SLACK_HOOK;
+  slackEventFilter: EventFilter;
+  slackBranchFilter?: string[];
 };
+
 export type GenericHook = BaseHook & {
   headers?: string;
   hookEvents: HookEvent[];

--- a/packages/common/src/run/types.ts
+++ b/packages/common/src/run/types.ts
@@ -2,6 +2,11 @@ import { Instance } from '../instance/types';
 
 export interface CommitData {
   sha: string;
+  branch?: string
+  authorName?: string
+  authorEmail?: string
+  message?: string
+  remoteOrigin?: string
 }
 export interface PlatformData {
   osName: string;

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -13,6 +13,7 @@ export type Scalars = {
   Float: number;
   GenericHookType: any;
   SlackHookType: any;
+  SlackEventFilter: any;
   GithubHookType: any;
   BitbucketHookType: any;
   DateTime: string;
@@ -182,6 +183,7 @@ export type SpecStats = {
 
 
 
+
 export type DeleteHookInput = {
   projectId: Scalars['ID'];
   hookId: Scalars['ID'];
@@ -200,10 +202,13 @@ export type SlackHook = {
   url: Scalars['String'];
   hookType: Scalars['SlackHookType'];
   hookEvents: Array<Scalars['String']>;
+  slackEventFilter: Scalars['SlackEventFilter'];
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateSlackHookInput = {
   projectId: Scalars['ID'];
+  slackEventFilter: Maybe<Scalars['SlackEventFilter']>;
 };
 
 export type UpdateSlackHookInput = {
@@ -211,6 +216,8 @@ export type UpdateSlackHookInput = {
   hookId: Scalars['ID'];
   url: Scalars['String'];
   hookEvents: Array<Scalars['String']>;
+  slackEventFilter: Scalars['SlackEventFilter'];
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type GithubHook = {
@@ -293,6 +300,8 @@ export type Hook = {
   bitbucketUsername: Maybe<Scalars['String']>;
   bitbucketToken: Maybe<Scalars['String']>;
   bitbucketBuildName: Maybe<Scalars['String']>;
+  slackEventFilter: Maybe<Scalars['String']>;
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type Project = {
@@ -313,6 +322,8 @@ export type HookInput = {
   bitbucketUsername: Maybe<Scalars['String']>;
   bitbucketToken: Maybe<Scalars['String']>;
   bitbucketBuildName: Maybe<Scalars['String']>;
+  slackEventFilter: Maybe<Scalars['String']>;
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateProjectInput = {
@@ -556,7 +567,7 @@ export type GetProjectQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectQuery = { __typename?: 'Query', project: Maybe<{ __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number>, hooks: Array<{ __typename?: 'Hook', hookId: Maybe<string>, url: Maybe<string>, headers: Maybe<string>, hookEvents: Maybe<Array<Maybe<string>>>, hookType: Maybe<string>, githubContext: Maybe<string>, githubToken: Maybe<string>, bitbucketUsername: Maybe<string>, bitbucketToken: Maybe<string>, bitbucketBuildName: Maybe<string> }> }> };
+export type GetProjectQuery = { __typename?: 'Query', project: Maybe<{ __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number>, hooks: Array<{ __typename?: 'Hook', hookId: Maybe<string>, url: Maybe<string>, headers: Maybe<string>, hookEvents: Maybe<Array<Maybe<string>>>, hookType: Maybe<string>, slackEventFilter: Maybe<string>, slackBranchFilter: Maybe<Array<Maybe<string>>>, githubContext: Maybe<string>, githubToken: Maybe<string>, bitbucketUsername: Maybe<string>, bitbucketToken: Maybe<string>, bitbucketBuildName: Maybe<string> }> }> };
 
 export type GetProjectsQueryVariables = Exact<{
   orderDirection: Maybe<OrderingOptions>;
@@ -592,7 +603,7 @@ export type CreateSlackHookMutationVariables = Exact<{
 }>;
 
 
-export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string> } };
+export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, slackEventFilter: any, slackBranchFilter: Maybe<Array<Maybe<string>>> } };
 
 export type DeleteHookMutationVariables = Exact<{
   input: DeleteHookInput;
@@ -936,6 +947,8 @@ export const GetProjectDocument = gql`
       headers
       hookEvents
       hookType
+      slackEventFilter
+      slackBranchFilter
       githubContext
       githubToken
       bitbucketUsername
@@ -1122,6 +1135,8 @@ export const CreateSlackHookDocument = gql`
     hookType
     url
     hookEvents
+    slackEventFilter
+    slackBranchFilter
   }
 }
     `;

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
   Float: number;
   GenericHookType: any;
   SlackHookType: any;
-  SlackEventFilter: any;
+  SlackResultFilter: any;
   GithubHookType: any;
   BitbucketHookType: any;
   DateTime: string;
@@ -202,13 +202,13 @@ export type SlackHook = {
   url: Scalars['String'];
   hookType: Scalars['SlackHookType'];
   hookEvents: Array<Scalars['String']>;
-  slackEventFilter: Scalars['SlackEventFilter'];
+  slackResultFilter: Scalars['SlackResultFilter'];
   slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type CreateSlackHookInput = {
   projectId: Scalars['ID'];
-  slackEventFilter: Maybe<Scalars['SlackEventFilter']>;
+  slackResultFilter: Maybe<Scalars['SlackResultFilter']>;
 };
 
 export type UpdateSlackHookInput = {
@@ -216,7 +216,7 @@ export type UpdateSlackHookInput = {
   hookId: Scalars['ID'];
   url: Scalars['String'];
   hookEvents: Array<Scalars['String']>;
-  slackEventFilter: Scalars['SlackEventFilter'];
+  slackResultFilter: Scalars['SlackResultFilter'];
   slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -300,7 +300,7 @@ export type Hook = {
   bitbucketUsername: Maybe<Scalars['String']>;
   bitbucketToken: Maybe<Scalars['String']>;
   bitbucketBuildName: Maybe<Scalars['String']>;
-  slackEventFilter: Maybe<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['String']>;
   slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -322,7 +322,7 @@ export type HookInput = {
   bitbucketUsername: Maybe<Scalars['String']>;
   bitbucketToken: Maybe<Scalars['String']>;
   bitbucketBuildName: Maybe<Scalars['String']>;
-  slackEventFilter: Maybe<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['String']>;
   slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -567,7 +567,7 @@ export type GetProjectQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectQuery = { __typename?: 'Query', project: Maybe<{ __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number>, hooks: Array<{ __typename?: 'Hook', hookId: Maybe<string>, url: Maybe<string>, headers: Maybe<string>, hookEvents: Maybe<Array<Maybe<string>>>, hookType: Maybe<string>, slackEventFilter: Maybe<string>, slackBranchFilter: Maybe<Array<Maybe<string>>>, githubContext: Maybe<string>, githubToken: Maybe<string>, bitbucketUsername: Maybe<string>, bitbucketToken: Maybe<string>, bitbucketBuildName: Maybe<string> }> }> };
+export type GetProjectQuery = { __typename?: 'Query', project: Maybe<{ __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number>, hooks: Array<{ __typename?: 'Hook', hookId: Maybe<string>, url: Maybe<string>, headers: Maybe<string>, hookEvents: Maybe<Array<Maybe<string>>>, hookType: Maybe<string>, slackResultFilter: Maybe<string>, slackBranchFilter: Maybe<Array<Maybe<string>>>, githubContext: Maybe<string>, githubToken: Maybe<string>, bitbucketUsername: Maybe<string>, bitbucketToken: Maybe<string>, bitbucketBuildName: Maybe<string> }> }> };
 
 export type GetProjectsQueryVariables = Exact<{
   orderDirection: Maybe<OrderingOptions>;
@@ -603,7 +603,7 @@ export type CreateSlackHookMutationVariables = Exact<{
 }>;
 
 
-export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, slackEventFilter: any, slackBranchFilter: Maybe<Array<Maybe<string>>> } };
+export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, slackResultFilter: any, slackBranchFilter: Maybe<Array<Maybe<string>>> } };
 
 export type DeleteHookMutationVariables = Exact<{
   input: DeleteHookInput;
@@ -947,7 +947,7 @@ export const GetProjectDocument = gql`
       headers
       hookEvents
       hookType
-      slackEventFilter
+      slackResultFilter
       slackBranchFilter
       githubContext
       githubToken
@@ -1135,7 +1135,7 @@ export const CreateSlackHookDocument = gql`
     hookType
     url
     hookEvents
-    slackEventFilter
+    slackResultFilter
     slackBranchFilter
   }
 }

--- a/packages/dashboard/src/project/getProject.graphql
+++ b/packages/dashboard/src/project/getProject.graphql
@@ -9,6 +9,9 @@ query getProject($projectId: ID!) {
       hookEvents
       hookType
 
+      slackEventFilter
+      slackBranchFilter
+
       githubContext
       githubToken
 

--- a/packages/dashboard/src/project/getProject.graphql
+++ b/packages/dashboard/src/project/getProject.graphql
@@ -9,7 +9,7 @@ query getProject($projectId: ID!) {
       hookEvents
       hookType
 
-      slackEventFilter
+      slackResultFilter
       slackBranchFilter
 
       githubContext

--- a/packages/dashboard/src/project/hook/createSlackHook.graphql
+++ b/packages/dashboard/src/project/hook/createSlackHook.graphql
@@ -4,5 +4,7 @@ mutation createSlackHook($input: CreateSlackHookInput!) {
     hookType
     url
     hookEvents
+    slackEventFilter
+    slackBranchFilter
   }
 }

--- a/packages/dashboard/src/project/hook/createSlackHook.graphql
+++ b/packages/dashboard/src/project/hook/createSlackHook.graphql
@@ -4,7 +4,7 @@ mutation createSlackHook($input: CreateSlackHookInput!) {
     hookType
     url
     hookEvents
-    slackEventFilter
+    slackResultFilter
     slackBranchFilter
   }
 }

--- a/packages/dashboard/src/project/hook/editBranchFilter.tsx
+++ b/packages/dashboard/src/project/hook/editBranchFilter.tsx
@@ -101,8 +101,9 @@ const BranchFilter = ({
   return (
     <Cell xs={12}>
       <InputFieldLabel
-        helpText='Filter for branches. You can specify branch names ("master")
-          and regular expressions (will be matched as /^YOUR_TEXT$/) which only will trigger a webhook.
+        helpText='Filter for branches. You can specify branch names which only will trigger a webhook.
+          You can use "?" and "*" wildcard characters
+          (e.g. "release-20??-*" pattern will match both "release-2021-1" and "release-2022-alpha" branches).
           Leaving this control blank activates all the branches.'
         label={<span>Branch Filter</span>}
         htmlFor="slackBranchFilter"

--- a/packages/dashboard/src/project/hook/editBranchFilter.tsx
+++ b/packages/dashboard/src/project/hook/editBranchFilter.tsx
@@ -1,0 +1,138 @@
+import { SlackHook } from '@sorry-cypress/common';
+import { InputFieldLabel } from '@src/components';
+import { Cell, Tag, TextField } from 'bold-ui';
+import React, { ChangeEvent, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+interface EditBranchFilterProps {
+  hook: SlackHook;
+  disabled: boolean;
+}
+
+export const EditBranchFilter = ({ hook, disabled }: EditBranchFilterProps) => {
+  const { errors, setError, clearErrors, control } = useFormContext();
+  return (
+    <Controller
+      control={control}
+      name="slackBranchFilter"
+      defaultValue={hook.slackBranchFilter}
+      render={({ value, onChange }) => (
+        <BranchFilter
+          hook={hook}
+          branches={value}
+          disabled={disabled}
+          errors={errors}
+          setError={setError}
+          clearErrors={clearErrors}
+          onChange={onChange}
+        />
+      )}
+    />
+  );
+};
+
+interface BranchFilterProps {
+  hook: SlackHook;
+  branches: string[];
+  disabled: boolean;
+  errors: any;
+  setError: any;
+  clearErrors: any;
+  onChange: any;
+}
+
+const BranchFilter = ({
+  hook,
+  branches,
+  disabled,
+  errors,
+  setError,
+  clearErrors,
+  onChange,
+}: BranchFilterProps) => {
+  const [inputBranchName, setInputBranchName] = useState('');
+
+  const handleInput = (e: ChangeEvent) => {
+    const input = (e.target as HTMLInputElement).value;
+    setInputBranchName(input);
+    if (input !== '') {
+      setError('slackBranchFilter', {
+        type: 'custom',
+        message:
+          'Please submit entered branch name by pressing "Enter" key or clicking "+" button',
+      });
+    } else {
+      clearErrors('slackBranchFilter');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addBranch();
+    }
+  };
+
+  const addBranch = () => {
+    if (!inputBranchName) {
+      return;
+    }
+
+    if (branches?.includes(inputBranchName)) {
+      setError('slackBranchFilter', {
+        type: 'custom',
+        message: 'Entered value already exists!',
+      });
+      return;
+    }
+
+    const newBranchesList = branches?.slice();
+    newBranchesList?.push(inputBranchName.trim().toLowerCase());
+    onChange(newBranchesList);
+
+    setInputBranchName('');
+  };
+
+  const deleteBranch = (name: string) => {
+    const newBranchesList = branches?.filter((item) => item !== name);
+    onChange(newBranchesList);
+  };
+
+  return (
+    <Cell xs={12}>
+      <InputFieldLabel
+        helpText='Filter for branches. You can specify branch names ("master")
+          and regular expressions (will be matched as /^YOUR_TEXT$/) which only will trigger a webhook.
+          Leaving this control blank activates all the branches.'
+        label={<span>Branch Filter</span>}
+        htmlFor="slackBranchFilter"
+        error={errors['slackBranchFilter']?.message}
+      >
+        <TextField
+          name={'slackBranchFilter'}
+          icon={'plus'}
+          placeholder="Enter branch name"
+          disabled={disabled}
+          onChange={handleInput}
+          onIconClick={() => addBranch()}
+          onKeyDown={handleKeyDown}
+          value={inputBranchName}
+        />
+        <Cell xs={12}>
+          {branches &&
+            branches.map((branch, index) => (
+              <Tag
+                key={index}
+                onRemove={() => deleteBranch(branch)}
+                removable
+                type="normal"
+                style={{ margin: '3px' }}
+              >
+                {branch}
+              </Tag>
+            ))}
+        </Cell>
+      </InputFieldLabel>
+    </Cell>
+  );
+};

--- a/packages/dashboard/src/project/hook/editBranchFilter.tsx
+++ b/packages/dashboard/src/project/hook/editBranchFilter.tsx
@@ -86,8 +86,8 @@ const BranchFilter = ({
       return;
     }
 
-    const newBranchesList = branches?.slice();
-    newBranchesList?.push(inputBranchName.trim().toLowerCase());
+    const newBranchesList = branches ? branches.slice() : [];
+    newBranchesList.push(inputBranchName.trim().toLowerCase());
     onChange(newBranchesList);
 
     setInputBranchName('');

--- a/packages/dashboard/src/project/hook/editHookEvents.tsx
+++ b/packages/dashboard/src/project/hook/editHookEvents.tsx
@@ -4,7 +4,7 @@ import { Cell, Select } from 'bold-ui';
 import { isEqual } from 'lodash';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { hookTypeToString } from './hook.utils';
+import { enumToString } from './hook.utils';
 
 interface EditHookEventsProps {
   hook: HookWithCustomEvents;
@@ -26,7 +26,7 @@ export const EditHookEvents = ({ hook, disabled }: EditHookEventsProps) => {
           render={({ name, value, onChange, ref }) => (
             <Select
               itemIsEqual={isEqual}
-              itemToString={hookTypeToString}
+              itemToString={enumToString}
               multiple={true}
               items={Object.keys(HookEvent)}
               name={name}

--- a/packages/dashboard/src/project/hook/hook.utils.ts
+++ b/packages/dashboard/src/project/hook/hook.utils.ts
@@ -1,8 +1,8 @@
 import { capitalize } from 'lodash';
 
-export const hookTypeToString = (item: string | null) => {
+export const enumToString = (item: string | null) => {
   if (!item) {
-    throw new Error('No item');
+    return "";
   }
   return capitalize(item).replace(/_/g, ' ');
 };

--- a/packages/dashboard/src/project/hook/hookEdit.tsx
+++ b/packages/dashboard/src/project/hook/hookEdit.tsx
@@ -14,7 +14,7 @@ import { useRouteMatch } from 'react-router';
 import { BitbucketHook } from './bitbucketHook';
 import { GenericHook } from './genericHook';
 import { GithubHook } from './githubHook';
-import { hookTypeToString } from './hook.utils';
+import { enumToString } from './hook.utils';
 import { HookFormAction } from './hookFormReducer';
 import { SlackHook } from './slackHook';
 
@@ -79,7 +79,7 @@ export const HookEdit = ({
         <Toggler
           toggleExpanded={toggleExpanded}
           isExpanded={isExpanded}
-          title={`${hookTypeToString(hook.hookType)}: ${
+          title={`${enumToString(hook.hookType)}: ${
             hook.url || 'New Hook'
           }`}
         />

--- a/packages/dashboard/src/project/hook/slackHook.tsx
+++ b/packages/dashboard/src/project/hook/slackHook.tsx
@@ -1,5 +1,5 @@
 import {
-  EventFilter,
+  ResultFilter,
   HookEvent,
   SlackHook as SlackHookType,
 } from '@sorry-cypress/common';
@@ -16,7 +16,7 @@ import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { EditBranchFilter } from './editBranchFilter';
 import { EditHookEvents } from './editHookEvents';
 import { useCurrentProjectId } from './useCurrentProjectId';
-import { httpUrlValidation, slackEventValidation } from './validation';
+import { httpUrlValidation, slackResultValidation } from './validation';
 
 interface SlackHookProps {
   hook: SlackHookType;
@@ -88,28 +88,28 @@ export const SlackHook = ({ hook }: SlackHookProps) => {
           <Cell xs={12}>
             <InputFieldLabel
               helpText="You can specify when a webhook should be triggered: only for failed builds, only for successful builds or for all builds."
-              label={<span>Event Filter</span>}
-              error={errors['slackEventFilter']?.message}
-              htmlFor="slackEventFilter"
+              label={<span>Result Filter</span>}
+              error={errors['slackResultFilter']?.message}
+              htmlFor="slackResultFilter"
               required
             >
               <Controller
-                name="slackEventFilter"
-                defaultValue={hook.slackEventFilter}
+                name="slackResultFilter"
+                defaultValue={hook.slackResultFilter}
                 rules={{
                   required: {
                     value: true,
                     message: 'Event Filter is required',
                   },
                   validate: {
-                    slackEventValidation,
+                    slackResultValidation,
                   },
                 }}
                 render={({ name, value, onChange, ref }) => (
                   <Select
                     itemIsEqual={isEqual}
                     itemToString={enumToString}
-                    items={Object.keys(EventFilter)}
+                    items={Object.keys(ResultFilter)}
                     name={name}
                     inputRef={ref}
                     onChange={(events: HookEvent[]) => onChange(events)}

--- a/packages/dashboard/src/project/hook/validation.ts
+++ b/packages/dashboard/src/project/hook/validation.ts
@@ -1,5 +1,5 @@
 import {
-  EventFilter,
+  ResultFilter,
   getBitbucketBuildUrl,
   getGithubStatusUrl,
 } from '@sorry-cypress/common';
@@ -46,8 +46,8 @@ export const httpUrlValidation = (value: string) => {
   }
 };
 
-export const slackEventValidation = (value: string) => {
-  if (Object.values(EventFilter).includes(value as EventFilter)) {
+export const slackResultValidation = (value: string) => {
+  if (Object.values(ResultFilter).includes(value as ResultFilter)) {
     return true;
   }
   return 'Please select an item';

--- a/packages/dashboard/src/project/hook/validation.ts
+++ b/packages/dashboard/src/project/hook/validation.ts
@@ -1,4 +1,5 @@
 import {
+  EventFilter,
   getBitbucketBuildUrl,
   getGithubStatusUrl,
 } from '@sorry-cypress/common';
@@ -43,4 +44,11 @@ export const httpUrlValidation = (value: string) => {
   } catch (e) {
     return 'Please enter a valid URL';
   }
+};
+
+export const slackEventValidation = (value: string) => {
+  if (Object.values(EventFilter).includes(value as EventFilter)) {
+    return true;
+  }
+  return 'Please select an item';
 };

--- a/packages/dashboard/src/project/hooksEditor.tsx
+++ b/packages/dashboard/src/project/hooksEditor.tsx
@@ -20,7 +20,7 @@ import {
   Text,
 } from 'bold-ui';
 import React, { useState } from 'react';
-import { hookTypeToString } from './hook/hook.utils';
+import { enumToString } from './hook/hook.utils';
 import { HookEdit } from './hook/hookEdit';
 import { useHooksFormReducer } from './hook/hookFormReducer';
 import { useCurrentProjectId } from './hook/useCurrentProjectId';
@@ -114,7 +114,7 @@ export const HooksEditor = () => {
         <HFlow alignItems="center">
           <Text>Select hook type: </Text>
           <Select
-            itemToString={hookTypeToString}
+            itemToString={enumToString}
             items={Object.keys(HookType).sort()}
             name="hookType"
             onChange={(value: HookType) => {

--- a/packages/director/src/lib/hooks/__tests__/fixtures/slackHook.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/slackHook.json
@@ -1,0 +1,9 @@
+{
+  "hookId": "testHook",
+  "url": "testUrl",
+  "headers": null,
+  "hookEvents": [],
+  "hookType": "SLACK_HOOK",
+  "slackResultFilter": "ALL",
+  "slackBranchFilter": []
+}

--- a/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequest.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequest.json
@@ -1,0 +1,48 @@
+{
+  "method": "post",
+  "url": "https://hooks.slack.com/services/123/XXX/zzz",
+  "data": {
+    "username": "sorry-cypress",
+    "blocks": [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":white_check_mark: *Run finished* (testCiBuildId)"
+        },
+        "accessory": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "View Results",
+            "emoji": true
+          },
+          "value": "view_run_testRunId",
+          "url": "http://localhost:8080/run/testRunId",
+          "action_id": "view_run_testRunId"
+        }
+      }
+    ],
+    "attachments": [
+      {
+        "color": "#0E8A16",
+        "blocks": [
+          {
+            "type": "section",
+            "fields": [
+              {
+                "type": "mrkdwn",
+                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Skipped:* 0\n\n\n:white_circle: *Failed*: 0"
+              },
+              {
+                "type": "mrkdwn",
+                "text": "*Branch:*\ntestBranch\n\n*Commit:*\ntestMessage"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "icon_url": "https://sorry-cypress.s3.amazonaws.com/images/icon-bg.png"
+  }
+}

--- a/packages/director/src/lib/hooks/__tests__/hooksReporter.test.ts
+++ b/packages/director/src/lib/hooks/__tests__/hooksReporter.test.ts
@@ -3,36 +3,35 @@ import {
   GithubHook,
   HookEvent,
   RunSummary,
+  SlackHook,
 } from '@sorry-cypress/common';
 import axios from 'axios';
 import { reportStatusToBitbucket } from '../reporters/bitbucket';
 import { reportStatusToGithub } from '../reporters/github';
+import { reportToSlack } from '../reporters/slack';
 import bitbucketHook from './fixtures/bitbucketHook.json';
 import bitbucketReportStatusRequest from './fixtures/bitbucketReportStatusRequest.json';
 import githubHook from './fixtures/githubHooks.json';
 import githubReportStatusRequest from './fixtures/githubReportStatusRequest.json';
 import runSummary from './fixtures/runSummary.json';
+import slackHook from './fixtures/slackHook.json';
+import slackReportStatusRequest from './fixtures/slackReportStatusRequest.json';
 
 jest.mock('axios');
 
-const ghHook = ({
-  ...githubHook,
-  url: 'https://github.com/test-company/test-project/',
-} as unknown) as GithubHook;
+beforeEach(() => {
+  ((axios as unknown) as jest.Mock).mockResolvedValueOnce({ status: 200 });
+});
 
-const bbHook = ({
-  ...bitbucketHook,
-  url: 'https://bitbucket.org/testcompany/testrepo.git',
-} as unknown) as BitBucketHook;
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
-describe('Report Status to Github / Bitbucket', () => {
-  beforeEach(() => {
-    ((axios as unknown) as jest.Mock).mockResolvedValueOnce({ status: 200 });
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+describe('Report status to GitHub', () => {
+  const ghHook = ({
+    ...githubHook,
+    url: 'https://github.com/test-company/test-project/',
+  } as unknown) as GithubHook;
 
   it('should send correct request to the github.com repo when run is started', async () => {
     await reportStatusToGithub({
@@ -68,6 +67,13 @@ describe('Report Status to Github / Bitbucket', () => {
         'https://gh.testcompany.com/api/v3/repos/test-company/test-project/statuses/testCommitSha',
     });
   });
+});
+
+describe('Report status to BitBucket', () => {
+  const bbHook = ({
+    ...bitbucketHook,
+    url: 'https://bitbucket.org/testcompany/testrepo.git',
+  } as unknown) as BitBucketHook;
 
   it('should send correct request to the bitbucket.org repo when run is started', async () => {
     await reportStatusToBitbucket({
@@ -82,6 +88,36 @@ describe('Report Status to Github / Bitbucket', () => {
       ...bitbucketReportStatusRequest,
       url:
         'https://api.bitbucket.org/2.0/repositories/testcompany/testrepo/commit/testCommitSha/statuses/build',
+    });
+  });
+});
+
+describe('Report status to Slack', () => {
+  const slkHook = ({
+    ...slackHook,
+    url: 'https://hooks.slack.com/services/123/XXX/zzz',
+    hookEvents: ['RUN_FINISH'],
+    slackResultFilter: 'ONLY_SUCCESSFUL',
+    slackBranchFilter: ['testBranch']
+  } as unknown) as SlackHook;
+
+  it('should send correct request to the Slack when run is finished', async () => {
+    await reportToSlack({
+      hook: slkHook,
+      runId: 'testRunId',
+      ciBuildId: 'testCiBuildId',
+      runSummary: (runSummary as unknown) as RunSummary,
+      hookEvent: HookEvent.RUN_FINISH,
+      commit: {
+        sha: 'testSha123',
+        branch: 'testBranch',
+        message: 'testMessage',
+      },
+    });
+
+    expect(axios).toBeCalledWith({
+      ...slackReportStatusRequest,
+      url: 'https://hooks.slack.com/services/123/XXX/zzz',
     });
   });
 });

--- a/packages/director/src/lib/hooks/__tests__/utils.test.ts
+++ b/packages/director/src/lib/hooks/__tests__/utils.test.ts
@@ -1,0 +1,154 @@
+import { HookEvent, RunSummary, SlackHook } from '@sorry-cypress/common';
+import {
+  isResultSuccessful,
+  isSlackBranchFilterPassed,
+  isSlackEventFilterPassed,
+  isSlackResultFilterPassed,
+} from '../utils';
+import slackHook from './fixtures/slackHook.json';
+
+describe('isSlackEventFilterPassed', () => {
+  it('Should return true when the filter is null', () => {
+    const slkHook = ({
+      ...slackHook,
+      hookEvents: null,
+    } as unknown) as SlackHook;
+
+    expect(isSlackEventFilterPassed(HookEvent.RUN_FINISH, slkHook)).toBe(true);
+  });
+  it('Should return true when the filter is empty', () => {
+    const slkHook = ({
+      ...slackHook,
+      hookEvents: [],
+    } as unknown) as SlackHook;
+
+    expect(isSlackEventFilterPassed(HookEvent.RUN_FINISH, slkHook)).toBe(true);
+  });
+  it('Should return true when the filter is matched', () => {
+    const slkHook = ({
+      ...slackHook,
+      hookEvents: ['RUN_FINISH'],
+    } as unknown) as SlackHook;
+
+    expect(isSlackEventFilterPassed(HookEvent.RUN_FINISH, slkHook)).toBe(true);
+  });
+  it("Should return false when the filter doesn't match", () => {
+    const slkHook = ({
+      ...slackHook,
+      hookEvents: ['RUN_FINISH'],
+    } as unknown) as SlackHook;
+
+    expect(isSlackEventFilterPassed(HookEvent.INSTANCE_FINISH, slkHook)).toBe(
+      false
+    );
+  });
+});
+
+describe('isSlackResultFilterPassed', () => {
+  it.each([
+    ['ONLY_FAILED', { failures: 1, passes: 0, pending: 0, skipped: 0 }],
+    ['ONLY_SUCCESSFUL', { failures: 0, passes: 1, pending: 0, skipped: 0 }],
+    ['ALL', { failures: 1, passes: 1, pending: 1, skipped: 1 }],
+    ['ALL', { failures: 0, passes: 0, pending: 0, skipped: 0 }],
+  ])(
+    'Should return true when %s filter is matched',
+    (filter: string, runSummary: RunSummary) => {
+      const slkHook = ({
+        ...slackHook,
+        slackResultFilter: filter,
+      } as unknown) as SlackHook;
+
+      expect(isSlackResultFilterPassed(slkHook, runSummary)).toBe(true);
+    }
+  );
+  it.each([
+    ['ONLY_FAILED', { failures: 0, passes: 1, pending: 0, skipped: 0 }],
+    ['ONLY_SUCCESSFUL', { failures: 1, passes: 1, pending: 0, skipped: 0 }],
+  ])(
+    "Should return false when %s filter doesn't match",
+    (filter: string, runSummary: RunSummary) => {
+      const slkHook = ({
+        ...slackHook,
+        slackResultFilter: filter,
+      } as unknown) as SlackHook;
+
+      expect(isSlackResultFilterPassed(slkHook, runSummary)).toBe(false);
+    }
+  );
+});
+
+describe('isSlackBranchFilterPassed', () => {
+  it('Should return true when the filter is null', () => {
+    const slkHook = ({
+      ...slackHook,
+      slackBranchFilter: null,
+    } as unknown) as SlackHook;
+
+    expect(isSlackBranchFilterPassed(slkHook, 'master')).toBe(true);
+  });
+  it('Should return true when the filter is empty', () => {
+    const slkHook = ({
+      ...slackHook,
+      slackBranchFilter: [],
+    } as unknown) as SlackHook;
+
+    expect(isSlackBranchFilterPassed(slkHook, 'master')).toBe(true);
+  });
+  it.each([
+    ['master', ['master']],
+    ['master', ['develop', 'master']],
+    ['master', ['m*r']],
+    ['master', ['m?ster']],
+    ['master', ['m??te*']],
+    ['master', ['m??*', 'develop']],
+    ['Master', ['master']],
+  ])(
+    'Should return true when "%s" branch matches the %p filter',
+    (branch: string, filter: [string]) => {
+      const slkHook = ({
+        ...slackHook,
+        slackBranchFilter: filter,
+      } as unknown) as SlackHook;
+
+      expect(isSlackBranchFilterPassed(slkHook, branch)).toBe(true);
+    }
+  );
+  it.each([
+    ['master', ['develop']],
+    ['master', ['develop', 'release']],
+    ['master', ['amaster']],
+    ['master', ['mastera']],
+    ['master123', ['master']],
+    ['master123', ['m*r']],
+    ['master123', ['master??']],
+  ])(
+    `Should return false when "%s" branch doesn't match the %p filter`,
+    (branch: string, filter: [string]) => {
+      const slkHook = ({
+        ...slackHook,
+        slackBranchFilter: filter,
+      } as unknown) as SlackHook;
+
+      expect(isSlackBranchFilterPassed(slkHook, branch)).toBe(false);
+    }
+  );
+});
+
+describe('isResultSuccessful', () => {
+  it.each([
+    [true, { failures: 0, passes: 1, pending: 0, skipped: 0 }],
+    [true, { failures: 0, passes: 0, pending: 1, skipped: 0 }],
+    [true, { failures: 0, passes: 0, pending: 0, skipped: 0 }],
+    [false, { failures: 1, passes: 1, pending: 1, skipped: 0 }],
+    [false, { failures: 0, passes: 1, pending: 1, skipped: 1 }],
+  ])(
+    'Should return "%p" when test run results are %p',
+    (result: boolean, runSummary: RunSummary) => {
+      const slkHook = ({
+        ...slackHook,
+      } as unknown) as SlackHook;
+
+      expect(isResultSuccessful(runSummary)).toBe(result);
+    }
+  );
+});

--- a/packages/director/src/lib/hooks/reporters/controller.ts
+++ b/packages/director/src/lib/hooks/reporters/controller.ts
@@ -37,7 +37,7 @@ export function reportToHook({
           runSummary,
           runId: run.runId,
           ciBuildId: run.meta.ciBuildId,
-          branch: run.meta.commit.branch,
+          commit: run.meta.commit,
           hookEvent,
         });
       }

--- a/packages/director/src/lib/hooks/reporters/controller.ts
+++ b/packages/director/src/lib/hooks/reporters/controller.ts
@@ -37,6 +37,7 @@ export function reportToHook({
           runSummary,
           runId: run.runId,
           ciBuildId: run.meta.ciBuildId,
+          branch: run.meta.commit.branch,
           hookEvent,
         });
       }
@@ -54,6 +55,7 @@ export function reportToHook({
         reportToGenericWebHook({
           hook,
           runId: run.runId,
+          branch: run.meta.commit.branch,
           runSummary,
           hookEvent,
         });

--- a/packages/director/src/lib/hooks/reporters/generic.ts
+++ b/packages/director/src/lib/hooks/reporters/generic.ts
@@ -5,16 +5,18 @@ import { shouldHookHandleEvent } from '../utils';
 
 export async function reportToGenericWebHook({
   hook,
+  runId,
+  branch,
   runSummary,
   hookEvent,
-  runId,
 }: {
-  runId: string;
   hook: GenericHook;
+  runId: string;
+  branch: string;
   runSummary: RunSummary;
   hookEvent: HookEvent;
 }) {
-  if (!shouldHookHandleEvent(hookEvent, hook)) {
+  if (!shouldHookHandleEvent(hookEvent, hook, runSummary, branch)) {
     return;
   }
 

--- a/packages/director/src/lib/hooks/reporters/slack.ts
+++ b/packages/director/src/lib/hooks/reporters/slack.ts
@@ -1,12 +1,12 @@
 import {
-CommitData,
-HookEvent,
-RunSummary,
-SlackHook
+  CommitData,
+  HookEvent,
+  RunSummary,
+  SlackHook,
 } from '@sorry-cypress/common';
 import { getDashboardRunURL } from '@src/lib/urls';
 import axios from 'axios';
-import { isResultSuccessful,shouldHookHandleEvent } from '../utils';
+import { isResultSuccessful, shouldHookHandleEvent } from '../utils';
 
 export async function reportToSlack({
   hook,
@@ -61,18 +61,11 @@ export async function reportToSlack({
     message.length > 100 ? `${message.substring(0, 100)}...` : message
   }`;
 
-  if (hookEvent === HookEvent.RUN_FINISH) {
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(null);
-      }, 5000);
-    });
-  }
-
-  return axios
-    .post(
-      hook.url,
-      JSON.stringify({
+  return (
+    axios({
+      method: 'post',
+      url: hook.url,
+      data: {
         username: 'sorry-cypress',
         blocks: [
           {
@@ -115,9 +108,9 @@ export async function reportToSlack({
           },
         ],
         icon_url: 'https://sorry-cypress.s3.amazonaws.com/images/icon-bg.png',
-      })
-    )
-    .catch((err) => {
+      },
+    }).catch((err) => {
       console.error(`Error: Hook Post to ${hook.url} responded with `, err);
-    });
+    }) || Promise.resolve()
+  );
 }

--- a/packages/director/src/lib/hooks/reporters/slack.ts
+++ b/packages/director/src/lib/hooks/reporters/slack.ts
@@ -9,14 +9,16 @@ export async function reportToSlack({
   ciBuildId,
   runSummary,
   hookEvent,
+  branch
 }: {
   hook: SlackHook;
   runId: string;
   ciBuildId: string;
   runSummary: RunSummary;
   hookEvent: HookEvent;
+  branch: string
 }) {
-  if (!shouldHookHandleEvent(hookEvent, hook)) {
+  if (!shouldHookHandleEvent(hookEvent, hook, runSummary, branch)) {
     return;
   }
   let title = 'Test suite started';
@@ -30,6 +32,9 @@ export async function reportToSlack({
   if (runSummary.skipped) {
     description += ` 👟 skipped ${runSummary.skipped}`;
   }
+  // Add Pending tests, and mark them as Skipped
+  // Skipped should be marked as failed according to
+  // https://github.com/cypress-io/cypress/issues/3092
 
   if (hookEvent === HookEvent.RUN_START) {
     title = '🚀 Started Run';

--- a/packages/director/src/lib/hooks/reporters/slack.ts
+++ b/packages/director/src/lib/hooks/reporters/slack.ts
@@ -1,7 +1,12 @@
-import { HookEvent, RunSummary, SlackHook } from '@sorry-cypress/common';
+import {
+CommitData,
+HookEvent,
+RunSummary,
+SlackHook
+} from '@sorry-cypress/common';
 import { getDashboardRunURL } from '@src/lib/urls';
 import axios from 'axios';
-import { shouldHookHandleEvent } from '../utils';
+import { isResultSuccessful,shouldHookHandleEvent } from '../utils';
 
 export async function reportToSlack({
   hook,
@@ -9,43 +14,54 @@ export async function reportToSlack({
   ciBuildId,
   runSummary,
   hookEvent,
-  branch
+  commit: { branch, message },
 }: {
   hook: SlackHook;
   runId: string;
   ciBuildId: string;
   runSummary: RunSummary;
   hookEvent: HookEvent;
-  branch: string
+  commit: CommitData;
 }) {
   if (!shouldHookHandleEvent(hookEvent, hook, runSummary, branch)) {
     return;
   }
-  let title = 'Test suite started';
-  let description = '';
-  if (runSummary.passes) {
-    description += ` ✅ passed ${runSummary.passes}`;
-  }
-  if (runSummary.failures) {
-    description += ` ❌ failed ${runSummary.failures}`;
-  }
-  if (runSummary.skipped) {
-    description += ` 👟 skipped ${runSummary.skipped}`;
-  }
-  // Add Pending tests, and mark them as Skipped
-  // Skipped should be marked as failed according to
-  // https://github.com/cypress-io/cypress/issues/3092
 
-  if (hookEvent === HookEvent.RUN_START) {
-    title = '🚀 Started Run';
+  let title = '';
+  switch (hookEvent) {
+    case HookEvent.RUN_START:
+      title = `:rocket: *Run started* (${ciBuildId})`;
+      break;
+    case HookEvent.INSTANCE_START:
+      title = `*Instance started* (${ciBuildId})`;
+      break;
+    case HookEvent.INSTANCE_FINISH:
+      title = `*Instance finished* (${ciBuildId})`;
+      break;
+    case HookEvent.RUN_FINISH:
+      title = `${
+        isResultSuccessful(runSummary) ? ':white_check_mark:' : ':x:'
+      } *Run finished* (${ciBuildId})`;
+      break;
   }
 
-  if (hookEvent === HookEvent.INSTANCE_FINISH) {
-    title = 'Test suite finished';
-  }
+  const { passes, pending, skipped, failures } = runSummary;
+  const resultsDescription =
+    `${
+      passes > 0 ? ':large_green_circle:' : ':white_circle:'
+    } *Passed:* ${passes}\n\n\n` +
+    `${
+      pending > 0 ? ':large_yellow_circle:' : ':white_circle:'
+    } *Skipped:* ${pending}\n\n\n` +
+    `${failures + skipped > 0 ? ':red_circle:' : ':white_circle:'} *Failed*: ${
+      failures + skipped
+    }`;
+
+  const commitDescription = `*Branch:*\n${branch}\n\n*Commit:*\n${
+    message.length > 100 ? `${message.substring(0, 100)}...` : message
+  }`;
 
   if (hookEvent === HookEvent.RUN_FINISH) {
-    title = '🏁 Finished Run';
     await new Promise((resolve) => {
       setTimeout(() => {
         resolve(null);
@@ -58,25 +74,44 @@ export async function reportToSlack({
       hook.url,
       JSON.stringify({
         username: 'sorry-cypress',
-        text: title,
         blocks: [
           {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `*${title} (${ciBuildId})*\n${description}`,
+              text: `${title}`,
             },
             accessory: {
               type: 'button',
               text: {
                 type: 'plain_text',
-                text: 'View Run',
+                text: 'View Results',
                 emoji: true,
               },
               value: `view_run_${runId}`,
               url: getDashboardRunURL(runId),
               action_id: `view_run_${runId}`,
             },
+          },
+        ],
+        attachments: [
+          {
+            color: isResultSuccessful(runSummary) ? '#0E8A16' : '#D93F0B',
+            blocks: [
+              {
+                type: 'section',
+                fields: [
+                  {
+                    type: 'mrkdwn',
+                    text: `${resultsDescription}`,
+                  },
+                  {
+                    type: 'mrkdwn',
+                    text: `${commitDescription}`,
+                  },
+                ],
+              },
+            ],
           },
         ],
         icon_url: 'https://sorry-cypress.s3.amazonaws.com/images/icon-bg.png',

--- a/packages/director/src/lib/hooks/utils.ts
+++ b/packages/director/src/lib/hooks/utils.ts
@@ -34,7 +34,7 @@ export function shouldHookHandleEvent(
       return false;
     }
 
-    if (hook.slackBranchFilter.length > 0) {
+    if (hook.slackBranchFilter && hook.slackBranchFilter.length > 0) {
       return !hook.slackBranchFilter.every((filter) => {
         const pattern = new RegExp(`^${filter}$`);
         return branch.search(pattern) === -1;

--- a/packages/director/src/lib/hooks/utils.ts
+++ b/packages/director/src/lib/hooks/utils.ts
@@ -35,10 +35,12 @@ export function shouldHookHandleEvent(
     }
 
     if (hook.slackBranchFilter && hook.slackBranchFilter.length > 0) {
-      return !hook.slackBranchFilter.every((filter) => {
+      const isBranchInFilter = !hook.slackBranchFilter.every((filter) => {
         const pattern = new RegExp(`^${filter}$`);
         return branch.search(pattern) === -1;
       });
+
+      if (!isBranchInFilter) return false;
     }
 
     if (!hook.hookEvents || !hook.hookEvents.length) {
@@ -51,4 +53,13 @@ export function shouldHookHandleEvent(
   }
 
   return false;
+}
+
+export function isResultSuccessful(runSummary: RunSummary) {
+  // Cypress is based on Mocha framework which has a not obvious results naming:
+  // Pending: tests you don't plan to run (it.skip(), for example)
+  // Skipped: tests you have planned to run, but, for example, before hook was failed
+  // Therefore we mark skipped tests as failed
+  // See details here: https://github.com/cypress-io/cypress/issues/3092
+  return !(runSummary.failures > 0 || runSummary.skipped > 0);
 }

--- a/packages/director/src/lib/hooks/utils.ts
+++ b/packages/director/src/lib/hooks/utils.ts
@@ -1,23 +1,53 @@
 import {
+  EventFilter,
   HookEvent,
   HookWithCustomEvents,
   isGithubHook,
+  isSlackHook,
+  RunSummary,
 } from '@sorry-cypress/common';
 
 export function shouldHookHandleEvent(
   event: HookEvent,
-  hook: HookWithCustomEvents
+  hook: HookWithCustomEvents,
+  runSummary: RunSummary,
+  branch: string
 ) {
   if (isGithubHook(hook)) {
     return true;
   }
 
-  if (!hook.hookEvents || !hook.hookEvents.length) {
-    return true;
-  }
+  if (isSlackHook(hook)) {
+    if (
+      hook.slackEventFilter === EventFilter.ONLY_FAILED &&
+      runSummary.failures === 0 &&
+      runSummary.skipped === 0
+    ) {
+      return false;
+    }
 
-  if (hook.hookEvents.includes(event)) {
-    return true;
+    if (
+      (hook.slackEventFilter === EventFilter.ONLY_SUCCESSFUL &&
+        runSummary.failures > 0) ||
+      runSummary.skipped > 0
+    ) {
+      return false;
+    }
+
+    if (hook.slackBranchFilter.length > 0) {
+      return !hook.slackBranchFilter.every((filter) => {
+        const pattern = new RegExp(`^${filter}$`);
+        return branch.search(pattern) === -1;
+      });
+    }
+
+    if (!hook.hookEvents || !hook.hookEvents.length) {
+      return true;
+    }
+
+    if (hook.hookEvents.includes(event)) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
We have faced with 3 issues in a current slack flow:

1. We want to get notification about only failed builds, not all builds.
2. We have dozens of branches, we want to know only about failed builds from **develop**, **master** and **release-\*** branches.
3. We need more information in slack message (commit message), also need to fix confusion with skipped/pending (https://github.com/cypress-io/cypress/issues/3092)

So, I have added:

1. Result filter (ALL, ONLY_FAILED, ONLY_SUCCESSFUL). Required field, default value is ALL.  
2. Branch filter (with '*' and '?' wildcards support). Optional field, empty state means filter is off, all branches are tracked. 
3. New Slack message layout.

Edit hook before:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/3439929/113700382-759c8f00-96df-11eb-8a1d-43793ffbb23f.png">

Edit hook after:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/3439929/113700516-98c73e80-96df-11eb-9dd7-6ff0c8256c0f.png">

Slack message before:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/3439929/113700706-d75cf900-96df-11eb-93c6-0c5e0f69d76a.png">

Slack message after:
Passed:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/3439929/113701075-55b99b00-96e0-11eb-8121-05727be36e87.png">
Failed:
<img width="618" alt="image" src="https://user-images.githubusercontent.com/3439929/113701124-65d17a80-96e0-11eb-89ea-fc23c20fd07e.png">
