### PR TITLE
Remove mongo $map usages to simpler syntax

### DIFF
--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -58,13 +58,7 @@ const projectAggregation = {
     specs: 1,
     createdAt: 1,
     completion: 1,
-    specsFull: {
-      $map: {
-        input: '$specs',
-        as: 'spec',
-        in: '$$spec.instanceId',
-      },
-    },
+    specsFull: '$specs.instanceId',
   },
 };
 

--- a/packages/director/src/execution/mongo/runs/run.model.ts
+++ b/packages/director/src/execution/mongo/runs/run.model.ts
@@ -30,13 +30,7 @@ const projectAggregation = {
     specs: 1,
     createdAt: 1,
     completion: 1,
-    specsFull: {
-      $map: {
-        input: '$specs',
-        as: 'spec',
-        in: '$$spec.instanceId',
-      },
-    },
+    specsFull: '$specs.instanceId',
   },
 };
 


### PR DESCRIPTION
$map is incompatible with the current version of Amazon DocumentDB, removing it allows sorry-cypress to be more easily deployed in AWS using the mongo "api-compatible" DocumentDB.

I have not used mongo heavily before, but from my testing this seems to give the same result.

Would potentially fix https://github.com/sorry-cypress/sorry-cypress/issues/133

