### PR TITLE
Successfully fire slack hooks without commit data

### DIFF
--- a/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequestWithoutCommitData.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequestWithoutCommitData.json
@@ -1,0 +1,44 @@
+{
+  "method": "post",
+  "url": "https://hooks.slack.com/services/123/XXX/zzz",
+  "data": {
+    "username": "sorry-cypress",
+    "blocks": [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": ":white_check_mark: *Run finished* (testCiBuildId)"
+        },
+        "accessory": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "View Results",
+            "emoji": true
+          },
+          "value": "view_run_testRunId",
+          "url": "http://localhost:8080/run/testRunId",
+          "action_id": "view_run_testRunId"
+        }
+      }
+    ],
+    "attachments": [
+      {
+        "color": "#0E8A16",
+        "blocks": [
+          {
+            "type": "section",
+            "fields": [
+              {
+                "type": "mrkdwn",
+                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Skipped:* 0\n\n\n:white_circle: *Failed*: 0"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "icon_url": "https://sorry-cypress.s3.amazonaws.com/images/icon-bg.png"
+  }
+}

--- a/packages/director/src/lib/hooks/__tests__/hooksReporter.test.ts
+++ b/packages/director/src/lib/hooks/__tests__/hooksReporter.test.ts
@@ -1,5 +1,6 @@
 import {
   BitBucketHook,
+  CommitData,
   GithubHook,
   HookEvent,
   RunSummary,
@@ -16,6 +17,7 @@ import githubReportStatusRequest from './fixtures/githubReportStatusRequest.json
 import runSummary from './fixtures/runSummary.json';
 import slackHook from './fixtures/slackHook.json';
 import slackReportStatusRequest from './fixtures/slackReportStatusRequest.json';
+import slackReportStatusRequestWithoutCommitData from './fixtures/slackReportStatusRequestWithoutCommitData.json';
 
 jest.mock('axios');
 
@@ -98,7 +100,7 @@ describe('Report status to Slack', () => {
     url: 'https://hooks.slack.com/services/123/XXX/zzz',
     hookEvents: ['RUN_FINISH'],
     slackResultFilter: 'ONLY_SUCCESSFUL',
-    slackBranchFilter: ['testBranch']
+    slackBranchFilter: ['testBranch'],
   } as unknown) as SlackHook;
 
   it('should send correct request to the Slack when run is finished', async () => {
@@ -117,6 +119,25 @@ describe('Report status to Slack', () => {
 
     expect(axios).toBeCalledWith({
       ...slackReportStatusRequest,
+      url: 'https://hooks.slack.com/services/123/XXX/zzz',
+    });
+  });
+
+  it('should report correctly to Slack with no commit data', async () => {
+    await reportToSlack({
+      hook: ({
+        ...slackHook,
+        url: 'https://hooks.slack.com/services/123/XXX/zzz',
+      } as unknown) as SlackHook,
+      runId: 'testRunId',
+      ciBuildId: 'testCiBuildId',
+      runSummary: (runSummary as unknown) as RunSummary,
+      hookEvent: HookEvent.RUN_FINISH,
+      commit: {} as CommitData,
+    });
+
+    expect(axios).toBeCalledWith({
+      ...slackReportStatusRequestWithoutCommitData,
       url: 'https://hooks.slack.com/services/123/XXX/zzz',
     });
   });

--- a/packages/director/src/lib/hooks/reporters/slack.ts
+++ b/packages/director/src/lib/hooks/reporters/slack.ts
@@ -57,9 +57,11 @@ export async function reportToSlack({
       failures + skipped
     }`;
 
-  const commitDescription = `*Branch:*\n${branch}\n\n*Commit:*\n${
-    message.length > 100 ? `${message.substring(0, 100)}...` : message
-  }`;
+  const commitDescription =
+    (branch || message) &&
+    `*Branch:*\n${branch}\n\n*Commit:*\n${
+      message?.length > 100 ? `${message.substring(0, 100)}...` : message
+    }`;
 
   return (
     axios({
@@ -98,10 +100,14 @@ export async function reportToSlack({
                     type: 'mrkdwn',
                     text: `${resultsDescription}`,
                   },
-                  {
-                    type: 'mrkdwn',
-                    text: `${commitDescription}`,
-                  },
+                  ...(commitDescription
+                    ? [
+                        {
+                          type: 'mrkdwn',
+                          text: `${commitDescription}`,
+                        },
+                      ]
+                    : []),
                 ],
               },
             ],


### PR DESCRIPTION
Commit data is not always present on a run. Slack hooks should still fire when commit branch and message are not set.

Was struggling to find where the run commit data (i.e. sha, branch and message) are currently captured from, but in our case they are never defined. This change ensures the slack hooks still fire when these are missing.

Thanks a lot for the PR 👍🏻

Your contribution is very valuable, we **really appreciate your time and effort**!

For bug fixes:

- [ ] Add a reference to the original issue
- [ ] Add a test and / or some kind of instructions to verify the fix

---

For new features:

- [ ] It's better to first discuss features proposal in [Discussions](https://github.com/sorry-cypress/sorry-cypress/discussions) or [Slack](https://sorry-cypress.slack.com/join/shared_invite/zt-eis1h6jl-tJELaD7q9UGEhMP8WHJOaw#/)
- [ ] Describe the use-case in details
- [ ] Ensure the solution is backwards-compatible
- [ ] Test it. Submit screenshots / outputs / tests together with the PR.

--- Side note ---

Time is very valuable resource and we are trying to use it wisely - your time and our time. The reality of maintaining on open-source software is:

- Adding a new code and / or feature complicates the maintenance
- Most people disappear after contributing a feature, leaving the support to core maintainers

Given that, please don't be offended if your PR is rejected or significantly modified.

P.S.
Here's an interesting discussion about OSS contributions https://changelog.com/podcast/433

❤️
