### PR TITLE
fix: correctly extract ciBuildId from Gitlab CI

### DIFF
--- a/packages/director/src/lib/ciBuildId.ts
+++ b/packages/director/src/lib/ciBuildId.ts
@@ -4,6 +4,7 @@ import { camelCase, isEmpty } from 'lodash';
 // https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.js#L133:L133
 const ciParams = [
   'CI_BUILD_ID',
+  'CI_PIPELINE_ID',
   'APPVEYOR_JOB_ID',
   'BUILD_BUILDID',
   'CODEBUILD_BUILD_ID',


### PR DESCRIPTION
CI_BUILD_ID is no longer set by Gitlab CI, per fsharp/FAKE#2290.

Not referencing an issue as there is none filed, but I can file/reference if needed.

I have confirmed CI_PIPELINE_ID is a viable env var by running Cypress with explicit `--ci-build-id $CI_PIPELINE_ID` (which works) and `--ci-build-id $CI_BUILD_ID` (which does not).