### PR TITLE
feature: allow reset of instance to facilitate retesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vscode/settings.json
+.idea
 # Runtime data
 pids
 *.pid

--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1,8 +1,17 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X];
+} &
+  { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -29,17 +38,14 @@ export type Query = {
   specStats?: Maybe<SpecStats>;
 };
 
-
 export type QueryProjectsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryProjectArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
@@ -47,22 +53,18 @@ export type QueryRunsArgs = {
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunFeedArgs = {
   cursor?: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QuerySpecStatsArgs = {
   spec: Scalars['String'];
@@ -74,6 +76,7 @@ export type Mutation = {
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
+  resetInstance: ResetInstanceResponse;
   deleteProject: DeleteProjectResponse;
   createProject: Project;
   updateProject: Project;
@@ -88,77 +91,66 @@ export type Mutation = {
   deleteHook: DeleteHookResponse;
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
   endDate: Scalars['DateTime'];
 };
 
+export type MutationResetInstanceArgs = {
+  instanceId: Scalars['ID'];
+};
 
 export type MutationDeleteProjectArgs = {
   projectId: Scalars['ID'];
 };
 
-
 export type MutationCreateProjectArgs = {
   project: CreateProjectInput;
 };
-
 
 export type MutationUpdateProjectArgs = {
   input: UpdateProjectInput;
 };
 
-
 export type MutationCreateGenericHookArgs = {
   input: CreateGenericHookInput;
 };
-
 
 export type MutationUpdateGenericHookArgs = {
   input: UpdateGenericHookInput;
 };
 
-
 export type MutationCreateBitbucketHookArgs = {
   input: CreateBitbucketHookInput;
 };
-
 
 export type MutationUpdateBitbucketHookArgs = {
   input: UpdateBitbucketHookInput;
 };
 
-
 export type MutationCreateGithubHookArgs = {
   input: CreateGithubHookInput;
 };
-
 
 export type MutationUpdateGithubHookArgs = {
   input: UpdateGithubHookInput;
 };
 
-
 export type MutationCreateSlackHookArgs = {
   input: CreateSlackHookInput;
 };
 
-
 export type MutationUpdateSlackHookArgs = {
   input: UpdateSlackHookInput;
 };
-
 
 export type MutationDeleteHookArgs = {
   input: DeleteHookInput;
@@ -177,11 +169,6 @@ export type SpecStats = {
   avgWallClockDuration: Scalars['Int'];
   count: Scalars['Int'];
 };
-
-
-
-
-
 
 export type DeleteHookInput = {
   projectId: Scalars['ID'];
@@ -391,6 +378,13 @@ export type RunMeta = {
   commit?: Maybe<Commit>;
 };
 
+export type ResetInstanceResponse = {
+  __typename?: 'ResetInstanceResponse';
+  instanceId: Scalars['ID'];
+  message: Scalars['String'];
+  success?: Maybe<Scalars['Boolean']>;
+};
+
 export type RunFeed = {
   __typename?: 'RunFeed';
   cursor: Scalars['String'];
@@ -468,7 +462,7 @@ export enum TestState {
   Failed = 'failed',
   Passed = 'passed',
   Pending = 'pending',
-  Skipped = 'skipped'
+  Skipped = 'skipped',
 }
 
 export type InstanceTest = {
@@ -508,10 +502,9 @@ export type TestAttempt = {
   wallClockDuration?: Maybe<Scalars['Int']>;
 };
 
-
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC'
+  Asc = 'ASC',
 }
 
 export type Filters = {
@@ -520,10 +513,7 @@ export type Filters = {
   like?: Maybe<Scalars['String']>;
 };
 
-
-
 export type ResolverTypeWrapper<T> = Promise<T> | T;
-
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
@@ -534,7 +524,9 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -560,9 +552,25 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -570,12 +578,26 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -584,11 +606,19 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -637,14 +667,21 @@ export type ResolversTypes = {
   RunSpec: ResolverTypeWrapper<RunSpec>;
   Commit: ResolverTypeWrapper<Commit>;
   RunMeta: ResolverTypeWrapper<RunMeta>;
+  ResetInstanceResponse: ResolverTypeWrapper<ResetInstanceResponse>;
   RunFeed: ResolverTypeWrapper<RunFeed>;
   Instance: ResolverTypeWrapper<Instance>;
-  InstanceResults: ResolverTypeWrapper<Omit<InstanceResults, 'tests'> & { tests?: Maybe<Array<ResolversTypes['InstanceTestUnion']>> }>;
+  InstanceResults: ResolverTypeWrapper<
+    Omit<InstanceResults, 'tests'> & {
+      tests?: Maybe<Array<ResolversTypes['InstanceTestUnion']>>;
+    }
+  >;
   InstanceStats: ResolverTypeWrapper<InstanceStats>;
   CypressConfig: ResolverTypeWrapper<CypressConfig>;
   InstanceScreeshot: ResolverTypeWrapper<InstanceScreeshot>;
   ReporterStats: ResolverTypeWrapper<ReporterStats>;
-  InstanceTestUnion: ResolversTypes['InstanceTest'] | ResolversTypes['InstanceTestV5'];
+  InstanceTestUnion:
+    | ResolversTypes['InstanceTest']
+    | ResolversTypes['InstanceTestV5'];
   TestState: TestState;
   InstanceTest: ResolverTypeWrapper<InstanceTest>;
   InstanceTestV5: ResolverTypeWrapper<InstanceTestV5>;
@@ -696,14 +733,19 @@ export type ResolversParentTypes = {
   RunSpec: RunSpec;
   Commit: Commit;
   RunMeta: RunMeta;
+  ResetInstanceResponse: ResetInstanceResponse;
   RunFeed: RunFeed;
   Instance: Instance;
-  InstanceResults: Omit<InstanceResults, 'tests'> & { tests?: Maybe<Array<ResolversParentTypes['InstanceTestUnion']>> };
+  InstanceResults: Omit<InstanceResults, 'tests'> & {
+    tests?: Maybe<Array<ResolversParentTypes['InstanceTestUnion']>>;
+  };
   InstanceStats: InstanceStats;
   CypressConfig: CypressConfig;
   InstanceScreeshot: InstanceScreeshot;
   ReporterStats: ReporterStats;
-  InstanceTestUnion: ResolversParentTypes['InstanceTest'] | ResolversParentTypes['InstanceTestV5'];
+  InstanceTestUnion:
+    | ResolversParentTypes['InstanceTest']
+    | ResolversParentTypes['InstanceTestV5'];
   InstanceTest: InstanceTest;
   InstanceTestV5: InstanceTestV5;
   TestError: TestError;
@@ -712,249 +754,620 @@ export type ResolversParentTypes = {
   Filters: Filters;
 };
 
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  projects?: Resolver<Array<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectsArgs, 'orderDirection' | 'filters'>>;
-  project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'id'>>;
-  runs?: Resolver<Array<Maybe<ResolversTypes['Run']>>, ParentType, ContextType, RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>>;
-  runFeed?: Resolver<ResolversTypes['RunFeed'], ParentType, ContextType, RequireFields<QueryRunFeedArgs, 'filters'>>;
-  run?: Resolver<Maybe<ResolversTypes['Run']>, ParentType, ContextType, RequireFields<QueryRunArgs, 'id'>>;
-  instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;
-  specStats?: Resolver<Maybe<ResolversTypes['SpecStats']>, ParentType, ContextType, RequireFields<QuerySpecStatsArgs, 'spec' | 'filters'>>;
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  projects?: Resolver<
+    Array<ResolversTypes['Project']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryProjectsArgs, 'orderDirection' | 'filters'>
+  >;
+  project?: Resolver<
+    Maybe<ResolversTypes['Project']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryProjectArgs, 'id'>
+  >;
+  runs?: Resolver<
+    Array<Maybe<ResolversTypes['Run']>>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>
+  >;
+  runFeed?: Resolver<
+    ResolversTypes['RunFeed'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunFeedArgs, 'filters'>
+  >;
+  run?: Resolver<
+    Maybe<ResolversTypes['Run']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunArgs, 'id'>
+  >;
+  instance?: Resolver<
+    Maybe<ResolversTypes['Instance']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryInstanceArgs, 'id'>
+  >;
+  specStats?: Resolver<
+    Maybe<ResolversTypes['SpecStats']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySpecStatsArgs, 'spec' | 'filters'>
+  >;
 };
 
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  deleteRun?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunArgs, 'runId'>>;
-  deleteRuns?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsArgs, 'runIds'>>;
-  deleteRunsInDateRange?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>>;
-  deleteProject?: Resolver<ResolversTypes['DeleteProjectResponse'], ParentType, ContextType, RequireFields<MutationDeleteProjectArgs, 'projectId'>>;
-  createProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationCreateProjectArgs, 'project'>>;
-  updateProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationUpdateProjectArgs, 'input'>>;
-  createGenericHook?: Resolver<ResolversTypes['GenericHook'], ParentType, ContextType, RequireFields<MutationCreateGenericHookArgs, 'input'>>;
-  updateGenericHook?: Resolver<ResolversTypes['GenericHook'], ParentType, ContextType, RequireFields<MutationUpdateGenericHookArgs, 'input'>>;
-  createBitbucketHook?: Resolver<ResolversTypes['BitbucketHook'], ParentType, ContextType, RequireFields<MutationCreateBitbucketHookArgs, 'input'>>;
-  updateBitbucketHook?: Resolver<ResolversTypes['BitbucketHook'], ParentType, ContextType, RequireFields<MutationUpdateBitbucketHookArgs, 'input'>>;
-  createGithubHook?: Resolver<ResolversTypes['GithubHook'], ParentType, ContextType, RequireFields<MutationCreateGithubHookArgs, 'input'>>;
-  updateGithubHook?: Resolver<ResolversTypes['GithubHook'], ParentType, ContextType, RequireFields<MutationUpdateGithubHookArgs, 'input'>>;
-  createSlackHook?: Resolver<ResolversTypes['SlackHook'], ParentType, ContextType, RequireFields<MutationCreateSlackHookArgs, 'input'>>;
-  updateSlackHook?: Resolver<ResolversTypes['SlackHook'], ParentType, ContextType, RequireFields<MutationUpdateSlackHookArgs, 'input'>>;
-  deleteHook?: Resolver<ResolversTypes['DeleteHookResponse'], ParentType, ContextType, RequireFields<MutationDeleteHookArgs, 'input'>>;
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  deleteRun?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunArgs, 'runId'>
+  >;
+  deleteRuns?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsArgs, 'runIds'>
+  >;
+  deleteRunsInDateRange?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>
+  >;
+  resetInstance?: Resolver<
+    ResolversTypes['ResetInstanceResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationResetInstanceArgs, 'instanceId'>
+  >;
+  deleteProject?: Resolver<
+    ResolversTypes['DeleteProjectResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteProjectArgs, 'projectId'>
+  >;
+  createProject?: Resolver<
+    ResolversTypes['Project'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateProjectArgs, 'project'>
+  >;
+  updateProject?: Resolver<
+    ResolversTypes['Project'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateProjectArgs, 'input'>
+  >;
+  createGenericHook?: Resolver<
+    ResolversTypes['GenericHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateGenericHookArgs, 'input'>
+  >;
+  updateGenericHook?: Resolver<
+    ResolversTypes['GenericHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateGenericHookArgs, 'input'>
+  >;
+  createBitbucketHook?: Resolver<
+    ResolversTypes['BitbucketHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateBitbucketHookArgs, 'input'>
+  >;
+  updateBitbucketHook?: Resolver<
+    ResolversTypes['BitbucketHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateBitbucketHookArgs, 'input'>
+  >;
+  createGithubHook?: Resolver<
+    ResolversTypes['GithubHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateGithubHookArgs, 'input'>
+  >;
+  updateGithubHook?: Resolver<
+    ResolversTypes['GithubHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateGithubHookArgs, 'input'>
+  >;
+  createSlackHook?: Resolver<
+    ResolversTypes['SlackHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateSlackHookArgs, 'input'>
+  >;
+  updateSlackHook?: Resolver<
+    ResolversTypes['SlackHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateSlackHookArgs, 'input'>
+  >;
+  deleteHook?: Resolver<
+    ResolversTypes['DeleteHookResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteHookArgs, 'input'>
+  >;
 };
 
-export type DeleteRunResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']> = {
+export type DeleteRunResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']
+> = {
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  runIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
+  runIds?: Resolver<
+    Array<Maybe<ResolversTypes['ID']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type SpecStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['SpecStats'] = ResolversParentTypes['SpecStats']> = {
+export type SpecStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SpecStats'] = ResolversParentTypes['SpecStats']
+> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  avgWallClockDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  avgWallClockDuration?: Resolver<
+    ResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >;
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface GenericHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GenericHookType'], any> {
+export interface GenericHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['GenericHookType'], any> {
   name: 'GenericHookType';
 }
 
-export interface SlackHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackHookType'], any> {
+export interface SlackHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['SlackHookType'], any> {
   name: 'SlackHookType';
 }
 
-export interface SlackResultFilterScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackResultFilter'], any> {
+export interface SlackResultFilterScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['SlackResultFilter'], any> {
   name: 'SlackResultFilter';
 }
 
-export interface GithubHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
+export interface GithubHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
   name: 'GithubHookType';
 }
 
-export interface BitbucketHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BitbucketHookType'], any> {
+export interface BitbucketHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['BitbucketHookType'], any> {
   name: 'BitbucketHookType';
 }
 
-export type DeleteHookResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteHookResponse'] = ResolversParentTypes['DeleteHookResponse']> = {
+export type DeleteHookResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteHookResponse'] = ResolversParentTypes['DeleteHookResponse']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type SlackHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['SlackHook'] = ResolversParentTypes['SlackHook']> = {
+export type SlackHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SlackHook'] = ResolversParentTypes['SlackHook']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hookType?: Resolver<ResolversTypes['SlackHookType'], ParentType, ContextType>;
-  hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  slackResultFilter?: Resolver<ResolversTypes['SlackResultFilter'], ParentType, ContextType>;
-  slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  hookEvents?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackResultFilter?: Resolver<
+    ResolversTypes['SlackResultFilter'],
+    ParentType,
+    ContextType
+  >;
+  slackBranchFilter?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type GithubHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['GithubHook'] = ResolversParentTypes['GithubHook']> = {
+export type GithubHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['GithubHook'] = ResolversParentTypes['GithubHook']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['GithubHookType'], ParentType, ContextType>;
-  githubToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['GithubHookType'],
+    ParentType,
+    ContextType
+  >;
+  githubToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  githubContext?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type BitbucketHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['BitbucketHook'] = ResolversParentTypes['BitbucketHook']> = {
+export type BitbucketHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['BitbucketHook'] = ResolversParentTypes['BitbucketHook']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['BitbucketHookType'], ParentType, ContextType>;
-  bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['BitbucketHookType'],
+    ParentType,
+    ContextType
+  >;
+  bitbucketUsername?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketBuildName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type GenericHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['GenericHook'] = ResolversParentTypes['GenericHook']> = {
+export type GenericHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['GenericHook'] = ResolversParentTypes['GenericHook']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['GenericHookType'], ParentType, ContextType>;
-  hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['GenericHookType'],
+    ParentType,
+    ContextType
+  >;
+  hookEvents?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type HookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Hook'] = ResolversParentTypes['Hook']> = {
+export type HookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Hook'] = ResolversParentTypes['Hook']
+> = {
   hookId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookEvents?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  hookEvents?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
   hookType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  slackResultFilter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  githubToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  githubContext?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketUsername?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketBuildName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackResultFilter?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackBranchFilter?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type ProjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']> = {
+export type ProjectResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']
+> = {
   projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   hooks?: Resolver<Array<ResolversTypes['Hook']>, ParentType, ContextType>;
-  inactivityTimeoutSeconds?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  inactivityTimeoutSeconds?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type DeleteProjectResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteProjectResponse'] = ResolversParentTypes['DeleteProjectResponse']> = {
+export type DeleteProjectResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteProjectResponse'] = ResolversParentTypes['DeleteProjectResponse']
+> = {
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  projectIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
+  projectIds?: Resolver<
+    Array<Maybe<ResolversTypes['ID']>>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunResolvers<ContextType = any, ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']> = {
+export type RunResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']
+> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   meta?: Resolver<ResolversTypes['RunMeta'], ParentType, ContextType>;
   specs?: Resolver<Array<ResolversTypes['RunSpec']>, ParentType, ContextType>;
-  completion?: Resolver<Maybe<ResolversTypes['RunCompletion']>, ParentType, ContextType>;
+  completion?: Resolver<
+    Maybe<ResolversTypes['RunCompletion']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunCompletionResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunCompletion'] = ResolversParentTypes['RunCompletion']> = {
+export type RunCompletionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunCompletion'] = ResolversParentTypes['RunCompletion']
+> = {
   completed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  inactivityTimeoutMs?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  inactivityTimeoutMs?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']> = {
+export type RunSpecResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']
+> = {
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  completedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  machineId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  claimedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  completedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  machineId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  results?: Resolver<
+    Maybe<ResolversTypes['InstanceResults']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type CommitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']> = {
+export type CommitResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']
+> = {
   sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authorName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  authorEmail?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  remoteOrigin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  remoteOrigin?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunMetaResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']> = {
+export type RunMetaResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']
+> = {
   ciBuildId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type RunFeedResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']> = {
+export type ResetInstanceResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ResetInstanceResponse'] = ResolversParentTypes['ResetInstanceResponse']
+> = {
+  instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunFeedResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']
+> = {
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']> = {
+export type InstanceResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
+> = {
   runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   run?: Resolver<ResolversTypes['Run'], ParentType, ContextType>;
   spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
+  results?: Resolver<
+    Maybe<ResolversTypes['InstanceResults']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']> = {
+export type InstanceResultsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']
+> = {
   stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  tests?: Resolver<Maybe<Array<ResolversTypes['InstanceTestUnion']>>, ParentType, ContextType>;
+  tests?: Resolver<
+    Maybe<Array<ResolversTypes['InstanceTestUnion']>>,
+    ParentType,
+    ContextType
+  >;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  screenshots?: Resolver<Array<ResolversTypes['InstanceScreeshot']>, ParentType, ContextType>;
-  cypressConfig?: Resolver<Maybe<ResolversTypes['CypressConfig']>, ParentType, ContextType>;
-  reporterStats?: Resolver<Maybe<ResolversTypes['ReporterStats']>, ParentType, ContextType>;
+  screenshots?: Resolver<
+    Array<ResolversTypes['InstanceScreeshot']>,
+    ParentType,
+    ContextType
+  >;
+  cypressConfig?: Resolver<
+    Maybe<ResolversTypes['CypressConfig']>,
+    ParentType,
+    ContextType
+  >;
+  reporterStats?: Resolver<
+    Maybe<ResolversTypes['ReporterStats']>,
+    ParentType,
+    ContextType
+  >;
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']> = {
+export type InstanceStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']
+> = {
   suites?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tests?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   skipped?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  wallClockEndedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    ResolversTypes['String'],
+    ParentType,
+    ContextType
+  >;
+  wallClockEndedAt?: Resolver<
+    ResolversTypes['String'],
+    ParentType,
+    ContextType
+  >;
   wallClockDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type CypressConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']> = {
+export type CypressConfigResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']
+> = {
   video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  videoUploadOnPasses?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  videoUploadOnPasses?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceScreeshotResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']> = {
+export type InstanceScreeshotResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']
+> = {
   screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  screenshotURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  screenshotURL?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type ReporterStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']> = {
+export type ReporterStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']
+> = {
   suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -966,48 +1379,92 @@ export type ReporterStatsResolvers<ContextType = any, ParentType extends Resolve
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceTestUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTestUnion'] = ResolversParentTypes['InstanceTestUnion']> = {
-  __resolveType: TypeResolveFn<'InstanceTest' | 'InstanceTestV5', ParentType, ContextType>;
+export type InstanceTestUnionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceTestUnion'] = ResolversParentTypes['InstanceTestUnion']
+> = {
+  __resolveType: TypeResolveFn<
+    'InstanceTest' | 'InstanceTestV5',
+    ParentType,
+    ContextType
+  >;
 };
 
-export type InstanceTestResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']> = {
+export type InstanceTestResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']
+> = {
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<ResolversTypes['TestState'], ParentType, ContextType>;
   body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stack?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type InstanceTestV5Resolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTestV5'] = ResolversParentTypes['InstanceTestV5']> = {
+export type InstanceTestV5Resolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceTestV5'] = ResolversParentTypes['InstanceTestV5']
+> = {
   testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<ResolversTypes['TestState'], ParentType, ContextType>;
   body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  displayError?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  attempts?: Resolver<Array<ResolversTypes['TestAttempt']>, ParentType, ContextType>;
+  displayError?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  attempts?: Resolver<
+    Array<ResolversTypes['TestAttempt']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type TestErrorResolvers<ContextType = any, ParentType extends ResolversParentTypes['TestError'] = ResolversParentTypes['TestError']> = {
+export type TestErrorResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TestError'] = ResolversParentTypes['TestError']
+> = {
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stack?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export type TestAttemptResolvers<ContextType = any, ParentType extends ResolversParentTypes['TestAttempt'] = ResolversParentTypes['TestAttempt']> = {
+export type TestAttemptResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TestAttempt'] = ResolversParentTypes['TestAttempt']
+> = {
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['TestError']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
 
@@ -1034,6 +1491,7 @@ export type Resolvers<ContextType = any> = {
   RunSpec?: RunSpecResolvers<ContextType>;
   Commit?: CommitResolvers<ContextType>;
   RunMeta?: RunMetaResolvers<ContextType>;
+  ResetInstanceResponse?: ResetInstanceResponseResolvers<ContextType>;
   RunFeed?: RunFeedResolvers<ContextType>;
   Instance?: InstanceResolvers<ContextType>;
   InstanceResults?: InstanceResultsResolvers<ContextType>;
@@ -1048,7 +1506,6 @@ export type Resolvers<ContextType = any> = {
   TestAttempt?: TestAttemptResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
 };
-
 
 /**
  * @deprecated

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -134,6 +134,13 @@ export const resolvers = {
         { dataSources }
       );
     },
+    resetInstance: async (
+      _: any,
+      { instanceId }: { instanceId: string },
+      { dataSources }: { dataSources: AppDatasources }
+    ) => {
+      return await dataSources.instancesAPI.resetInstanceById(instanceId);
+    },
     deleteRuns: async (
       _: any,
       { runIds }: { runIds: string[] },

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -24,6 +24,7 @@ type Mutation {
     startDate: DateTime!
     endDate: DateTime!
   ): DeleteRunResponse!
+  resetInstance(instanceId: ID!): ResetInstanceResponse!
   deleteProject(projectId: ID!): DeleteProjectResponse!
   createProject(project: CreateProjectInput!): Project!
   updateProject(input: UpdateProjectInput!): Project!
@@ -252,6 +253,12 @@ type RunMeta {
   ciBuildId: String!
   projectId: String!
   commit: Commit
+}
+
+type ResetInstanceResponse {
+  instanceId: ID!
+  message: String!
+  success: Boolean
 }
 
 ### RunFeed - runs representation for the landing page

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -1,9 +1,13 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -30,17 +34,14 @@ export type Query = {
   specStats: Maybe<SpecStats>;
 };
 
-
 export type QueryProjectsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryProjectArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QueryRunsArgs = {
   orderDirection?: Maybe<OrderingOptions>;
@@ -48,22 +49,18 @@ export type QueryRunsArgs = {
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunFeedArgs = {
   cursor: Maybe<Scalars['String']>;
   filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
 
-
 export type QueryInstanceArgs = {
   id: Scalars['ID'];
 };
-
 
 export type QuerySpecStatsArgs = {
   spec: Scalars['String'];
@@ -75,6 +72,7 @@ export type Mutation = {
   deleteRun: DeleteRunResponse;
   deleteRuns: DeleteRunResponse;
   deleteRunsInDateRange: DeleteRunResponse;
+  resetInstance: ResetInstanceResponse;
   deleteProject: DeleteProjectResponse;
   createProject: Project;
   updateProject: Project;
@@ -89,77 +87,66 @@ export type Mutation = {
   deleteHook: DeleteHookResponse;
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
   runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
   startDate: Scalars['DateTime'];
   endDate: Scalars['DateTime'];
 };
 
+export type MutationResetInstanceArgs = {
+  instanceId: Scalars['ID'];
+};
 
 export type MutationDeleteProjectArgs = {
   projectId: Scalars['ID'];
 };
 
-
 export type MutationCreateProjectArgs = {
   project: CreateProjectInput;
 };
-
 
 export type MutationUpdateProjectArgs = {
   input: UpdateProjectInput;
 };
 
-
 export type MutationCreateGenericHookArgs = {
   input: CreateGenericHookInput;
 };
-
 
 export type MutationUpdateGenericHookArgs = {
   input: UpdateGenericHookInput;
 };
 
-
 export type MutationCreateBitbucketHookArgs = {
   input: CreateBitbucketHookInput;
 };
-
 
 export type MutationUpdateBitbucketHookArgs = {
   input: UpdateBitbucketHookInput;
 };
 
-
 export type MutationCreateGithubHookArgs = {
   input: CreateGithubHookInput;
 };
-
 
 export type MutationUpdateGithubHookArgs = {
   input: UpdateGithubHookInput;
 };
 
-
 export type MutationCreateSlackHookArgs = {
   input: CreateSlackHookInput;
 };
 
-
 export type MutationUpdateSlackHookArgs = {
   input: UpdateSlackHookInput;
 };
-
 
 export type MutationDeleteHookArgs = {
   input: DeleteHookInput;
@@ -178,11 +165,6 @@ export type SpecStats = {
   avgWallClockDuration: Scalars['Int'];
   count: Scalars['Int'];
 };
-
-
-
-
-
 
 export type DeleteHookInput = {
   projectId: Scalars['ID'];
@@ -392,6 +374,13 @@ export type RunMeta = {
   commit: Maybe<Commit>;
 };
 
+export type ResetInstanceResponse = {
+  __typename?: 'ResetInstanceResponse';
+  instanceId: Scalars['ID'];
+  message: Scalars['String'];
+  success: Maybe<Scalars['Boolean']>;
+};
+
 export type RunFeed = {
   __typename?: 'RunFeed';
   cursor: Scalars['String'];
@@ -469,7 +458,7 @@ export enum TestState {
   Failed = 'failed',
   Passed = 'passed',
   Pending = 'pending',
-  Skipped = 'skipped'
+  Skipped = 'skipped',
 }
 
 export type InstanceTest = {
@@ -509,10 +498,9 @@ export type TestAttempt = {
   wallClockDuration: Maybe<Scalars['Int']>;
 };
 
-
 export enum OrderingOptions {
   Desc = 'DESC',
-  Asc = 'ASC'
+  Asc = 'ASC',
 }
 
 export type Filters = {
@@ -525,312 +513,564 @@ export type GetInstanceQueryVariables = Exact<{
   instanceId: Scalars['ID'];
 }>;
 
-
-export type GetInstanceQuery = { __typename?: 'Query', instance: Maybe<{ __typename?: 'Instance', instanceId: string, runId: string, spec: string, run: { __typename?: 'Run', runId: string, meta: { __typename?: 'RunMeta', ciBuildId: string, projectId: string } }, results: Maybe<{ __typename?: 'InstanceResults', error: Maybe<string>, videoUrl: Maybe<string>, stats: (
-        { __typename?: 'InstanceStats' }
-        & AllInstanceStatsFragment
-      ), tests: Maybe<Array<{ __typename?: 'InstanceTest', testId: string, title: Array<string>, state: TestState, wallClockDuration: Maybe<number>, wallClockStartedAt: Maybe<string>, error: Maybe<string>, stack: Maybe<string> } | { __typename?: 'InstanceTestV5', testId: string, title: Array<string>, state: TestState, displayError: Maybe<string>, attempts: Array<{ __typename?: 'TestAttempt', state: Maybe<string>, wallClockDuration: Maybe<number>, wallClockStartedAt: Maybe<string>, error: Maybe<{ __typename?: 'TestError', name: string, message: string, stack: string }> }> }>>, screenshots: Array<{ __typename?: 'InstanceScreeshot', testId: string, screenshotId: string, height: number, width: number, screenshotURL: Maybe<string> }>, cypressConfig: Maybe<{ __typename?: 'CypressConfig', video: boolean, videoUploadOnPasses: boolean }> }> }> };
+export type GetInstanceQuery = {
+  __typename?: 'Query';
+  instance: Maybe<{
+    __typename?: 'Instance';
+    instanceId: string;
+    runId: string;
+    spec: string;
+    run: {
+      __typename?: 'Run';
+      runId: string;
+      meta: { __typename?: 'RunMeta'; ciBuildId: string; projectId: string };
+    };
+    results: Maybe<{
+      __typename?: 'InstanceResults';
+      error: Maybe<string>;
+      videoUrl: Maybe<string>;
+      stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+      tests: Maybe<
+        Array<
+          | {
+              __typename?: 'InstanceTest';
+              testId: string;
+              title: Array<string>;
+              state: TestState;
+              wallClockDuration: Maybe<number>;
+              wallClockStartedAt: Maybe<string>;
+              error: Maybe<string>;
+              stack: Maybe<string>;
+            }
+          | {
+              __typename?: 'InstanceTestV5';
+              testId: string;
+              title: Array<string>;
+              state: TestState;
+              displayError: Maybe<string>;
+              attempts: Array<{
+                __typename?: 'TestAttempt';
+                state: Maybe<string>;
+                wallClockDuration: Maybe<number>;
+                wallClockStartedAt: Maybe<string>;
+                error: Maybe<{
+                  __typename?: 'TestError';
+                  name: string;
+                  message: string;
+                  stack: string;
+                }>;
+              }>;
+            }
+        >
+      >;
+      screenshots: Array<{
+        __typename?: 'InstanceScreeshot';
+        testId: string;
+        screenshotId: string;
+        height: number;
+        width: number;
+        screenshotURL: Maybe<string>;
+      }>;
+      cypressConfig: Maybe<{
+        __typename?: 'CypressConfig';
+        video: boolean;
+        videoUploadOnPasses: boolean;
+      }>;
+    }>;
+  }>;
+};
 
 export type CreateProjectMutationVariables = Exact<{
   project: CreateProjectInput;
 }>;
 
-
-export type CreateProjectMutation = { __typename?: 'Mutation', createProject: { __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number> } };
+export type CreateProjectMutation = {
+  __typename?: 'Mutation';
+  createProject: {
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+  };
+};
 
 export type DeleteProjectMutationVariables = Exact<{
   projectId: Scalars['ID'];
 }>;
 
-
-export type DeleteProjectMutation = { __typename?: 'Mutation', deleteProject: { __typename?: 'DeleteProjectResponse', success: boolean, message: string, projectIds: Array<Maybe<string>> } };
+export type DeleteProjectMutation = {
+  __typename?: 'Mutation';
+  deleteProject: {
+    __typename?: 'DeleteProjectResponse';
+    success: boolean;
+    message: string;
+    projectIds: Array<Maybe<string>>;
+  };
+};
 
 export type GetProjectQueryVariables = Exact<{
   projectId: Scalars['ID'];
 }>;
 
-
-export type GetProjectQuery = { __typename?: 'Query', project: Maybe<{ __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number>, hooks: Array<{ __typename?: 'Hook', hookId: Maybe<string>, url: Maybe<string>, headers: Maybe<string>, hookEvents: Maybe<Array<Maybe<string>>>, hookType: Maybe<string>, slackResultFilter: Maybe<string>, slackBranchFilter: Maybe<Array<Maybe<string>>>, githubContext: Maybe<string>, githubToken: Maybe<string>, bitbucketUsername: Maybe<string>, bitbucketToken: Maybe<string>, bitbucketBuildName: Maybe<string> }> }> };
+export type GetProjectQuery = {
+  __typename?: 'Query';
+  project: Maybe<{
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+    hooks: Array<{
+      __typename?: 'Hook';
+      hookId: Maybe<string>;
+      url: Maybe<string>;
+      headers: Maybe<string>;
+      hookEvents: Maybe<Array<Maybe<string>>>;
+      hookType: Maybe<string>;
+      slackResultFilter: Maybe<string>;
+      slackBranchFilter: Maybe<Array<Maybe<string>>>;
+      githubContext: Maybe<string>;
+      githubToken: Maybe<string>;
+      bitbucketUsername: Maybe<string>;
+      bitbucketToken: Maybe<string>;
+      bitbucketBuildName: Maybe<string>;
+    }>;
+  }>;
+};
 
 export type GetProjectsQueryVariables = Exact<{
   orderDirection: Maybe<OrderingOptions>;
   filters: Maybe<Array<Maybe<Filters>> | Maybe<Filters>>;
 }>;
 
-
-export type GetProjectsQuery = { __typename?: 'Query', projects: Array<{ __typename?: 'Project', projectId: string }> };
+export type GetProjectsQuery = {
+  __typename?: 'Query';
+  projects: Array<{ __typename?: 'Project'; projectId: string }>;
+};
 
 export type CreateBitbucketHookMutationVariables = Exact<{
   input: CreateBitbucketHookInput;
 }>;
 
-
-export type CreateBitbucketHookMutation = { __typename?: 'Mutation', createBitbucketHook: { __typename?: 'BitbucketHook', projectId: string, hookId: string, hookType: any, url: string, bitbucketUsername: Maybe<string>, bitbucketBuildName: Maybe<string> } };
+export type CreateBitbucketHookMutation = {
+  __typename?: 'Mutation';
+  createBitbucketHook: {
+    __typename?: 'BitbucketHook';
+    projectId: string;
+    hookId: string;
+    hookType: any;
+    url: string;
+    bitbucketUsername: Maybe<string>;
+    bitbucketBuildName: Maybe<string>;
+  };
+};
 
 export type CreateGenericHookMutationVariables = Exact<{
   input: CreateGenericHookInput;
 }>;
 
-
-export type CreateGenericHookMutation = { __typename?: 'Mutation', createGenericHook: { __typename?: 'GenericHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, headers: Maybe<string> } };
+export type CreateGenericHookMutation = {
+  __typename?: 'Mutation';
+  createGenericHook: {
+    __typename?: 'GenericHook';
+    hookId: string;
+    hookType: any;
+    url: string;
+    hookEvents: Array<string>;
+    headers: Maybe<string>;
+  };
+};
 
 export type CreateGithubHookMutationVariables = Exact<{
   input: CreateGithubHookInput;
 }>;
 
-
-export type CreateGithubHookMutation = { __typename?: 'Mutation', createGithubHook: { __typename?: 'GithubHook', projectId: string, hookId: string, hookType: any, url: string, githubToken: Maybe<string>, githubContext: Maybe<string> } };
+export type CreateGithubHookMutation = {
+  __typename?: 'Mutation';
+  createGithubHook: {
+    __typename?: 'GithubHook';
+    projectId: string;
+    hookId: string;
+    hookType: any;
+    url: string;
+    githubToken: Maybe<string>;
+    githubContext: Maybe<string>;
+  };
+};
 
 export type CreateSlackHookMutationVariables = Exact<{
   input: CreateSlackHookInput;
 }>;
 
-
-export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, slackResultFilter: any, slackBranchFilter: Maybe<Array<Maybe<string>>> } };
+export type CreateSlackHookMutation = {
+  __typename?: 'Mutation';
+  createSlackHook: {
+    __typename?: 'SlackHook';
+    hookId: string;
+    hookType: any;
+    url: string;
+    hookEvents: Array<string>;
+    slackResultFilter: any;
+    slackBranchFilter: Maybe<Array<Maybe<string>>>;
+  };
+};
 
 export type DeleteHookMutationVariables = Exact<{
   input: DeleteHookInput;
 }>;
 
-
-export type DeleteHookMutation = { __typename?: 'Mutation', deleteHook: { __typename?: 'DeleteHookResponse', hookId: string, projectId: string } };
+export type DeleteHookMutation = {
+  __typename?: 'Mutation';
+  deleteHook: {
+    __typename?: 'DeleteHookResponse';
+    hookId: string;
+    projectId: string;
+  };
+};
 
 export type UpdateBitbucketHookMutationVariables = Exact<{
   input: UpdateBitbucketHookInput;
 }>;
 
-
-export type UpdateBitbucketHookMutation = { __typename?: 'Mutation', updateBitbucketHook: { __typename?: 'BitbucketHook', hookId: string } };
+export type UpdateBitbucketHookMutation = {
+  __typename?: 'Mutation';
+  updateBitbucketHook: { __typename?: 'BitbucketHook'; hookId: string };
+};
 
 export type UpdateGenericHookMutationVariables = Exact<{
   input: UpdateGenericHookInput;
 }>;
 
-
-export type UpdateGenericHookMutation = { __typename?: 'Mutation', updateGenericHook: { __typename?: 'GenericHook', hookId: string } };
+export type UpdateGenericHookMutation = {
+  __typename?: 'Mutation';
+  updateGenericHook: { __typename?: 'GenericHook'; hookId: string };
+};
 
 export type UpdateGithubHookMutationVariables = Exact<{
   input: UpdateGithubHookInput;
 }>;
 
-
-export type UpdateGithubHookMutation = { __typename?: 'Mutation', updateGithubHook: { __typename?: 'GithubHook', hookId: string } };
+export type UpdateGithubHookMutation = {
+  __typename?: 'Mutation';
+  updateGithubHook: { __typename?: 'GithubHook'; hookId: string };
+};
 
 export type UpdateSlackHookMutationVariables = Exact<{
   input: UpdateSlackHookInput;
 }>;
 
-
-export type UpdateSlackHookMutation = { __typename?: 'Mutation', updateSlackHook: { __typename?: 'SlackHook', hookId: string } };
+export type UpdateSlackHookMutation = {
+  __typename?: 'Mutation';
+  updateSlackHook: { __typename?: 'SlackHook'; hookId: string };
+};
 
 export type UpdateProjectMutationVariables = Exact<{
   input: UpdateProjectInput;
 }>;
 
-
-export type UpdateProjectMutation = { __typename?: 'Mutation', updateProject: { __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: Maybe<number> } };
+export type UpdateProjectMutation = {
+  __typename?: 'Mutation';
+  updateProject: {
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+  };
+};
 
 export type DeleteRunMutationVariables = Exact<{
   runId: Scalars['ID'];
 }>;
 
-
-export type DeleteRunMutation = { __typename?: 'Mutation', deleteRun: { __typename?: 'DeleteRunResponse', success: boolean, message: string, runIds: Array<Maybe<string>> } };
+export type DeleteRunMutation = {
+  __typename?: 'Mutation';
+  deleteRun: {
+    __typename?: 'DeleteRunResponse';
+    success: boolean;
+    message: string;
+    runIds: Array<Maybe<string>>;
+  };
+};
 
 export type GetSpecStatsQueryVariables = Exact<{
   spec: Scalars['String'];
 }>;
 
+export type GetSpecStatsQuery = {
+  __typename?: 'Query';
+  specStats: Maybe<{
+    __typename?: 'SpecStats';
+    spec: string;
+    count: number;
+    avgWallClockDuration: number;
+  }>;
+};
 
-export type GetSpecStatsQuery = { __typename?: 'Query', specStats: Maybe<{ __typename?: 'SpecStats', spec: string, count: number, avgWallClockDuration: number }> };
+export type ResetInstanceMutationVariables = Exact<{
+  instanceId: Scalars['ID'];
+}>;
+
+export type ResetInstanceMutation = {
+  __typename?: 'Mutation';
+  resetInstance: {
+    __typename?: 'ResetInstanceResponse';
+    success: Maybe<boolean>;
+    message: string;
+    instanceId: string;
+  };
+};
 
 export type GetRunQueryVariables = Exact<{
   runId: Scalars['ID'];
 }>;
 
+export type GetRunQuery = {
+  __typename?: 'Query';
+  run: Maybe<{
+    __typename?: 'Run';
+    runId: string;
+    createdAt: string;
+    completion: Maybe<
+      { __typename?: 'RunCompletion' } & RunSummaryCompletionFragment
+    >;
+    meta: { __typename?: 'RunMeta' } & RunSummaryMetaFragment;
+    specs: Array<{ __typename?: 'RunSpec' } & RunDetailSpecFragment>;
+  }>;
+};
 
-export type GetRunQuery = { __typename?: 'Query', run: Maybe<{ __typename?: 'Run', runId: string, createdAt: string, completion: Maybe<(
-      { __typename?: 'RunCompletion' }
-      & RunSummaryCompletionFragment
-    )>, meta: (
-      { __typename?: 'RunMeta' }
-      & RunSummaryMetaFragment
-    ), specs: Array<(
-      { __typename?: 'RunSpec' }
-      & RunDetailSpecFragment
-    )> }> };
-
-export type RunDetailSpecFragment = { __typename?: 'RunSpec', instanceId: string, spec: string, claimedAt: Maybe<string>, machineId: Maybe<string>, groupId: Maybe<string>, results: Maybe<{ __typename?: 'InstanceResults', error: Maybe<string>, tests: Maybe<Array<{ __typename?: 'InstanceTest', state: TestState } | { __typename?: 'InstanceTestV5', state: TestState, attempts: Array<{ __typename?: 'TestAttempt', state: Maybe<string> }> }>>, stats: (
-      { __typename?: 'InstanceStats' }
-      & AllInstanceStatsFragment
-    ) }> };
+export type RunDetailSpecFragment = {
+  __typename?: 'RunSpec';
+  instanceId: string;
+  spec: string;
+  claimedAt: Maybe<string>;
+  machineId: Maybe<string>;
+  groupId: Maybe<string>;
+  results: Maybe<{
+    __typename?: 'InstanceResults';
+    error: Maybe<string>;
+    tests: Maybe<
+      Array<
+        | { __typename?: 'InstanceTest'; state: TestState }
+        | {
+            __typename?: 'InstanceTestV5';
+            state: TestState;
+            attempts: Array<{
+              __typename?: 'TestAttempt';
+              state: Maybe<string>;
+            }>;
+          }
+      >
+    >;
+    stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+  }>;
+};
 
 export type GetRunSummaryQueryVariables = Exact<{
   runId: Scalars['ID'];
 }>;
 
+export type GetRunSummaryQuery = {
+  __typename?: 'Query';
+  run: Maybe<{
+    __typename?: 'Run';
+    runId: string;
+    createdAt: string;
+    meta: { __typename?: 'RunMeta' } & RunSummaryMetaFragment;
+    completion: Maybe<
+      { __typename?: 'RunCompletion' } & RunSummaryCompletionFragment
+    >;
+    specs: Array<{ __typename?: 'RunSpec' } & RunSummarySpecFragment>;
+  }>;
+};
 
-export type GetRunSummaryQuery = { __typename?: 'Query', run: Maybe<{ __typename?: 'Run', runId: string, createdAt: string, meta: (
-      { __typename?: 'RunMeta' }
-      & RunSummaryMetaFragment
-    ), completion: Maybe<(
-      { __typename?: 'RunCompletion' }
-      & RunSummaryCompletionFragment
-    )>, specs: Array<(
-      { __typename?: 'RunSpec' }
-      & RunSummarySpecFragment
-    )> }> };
+export type AllInstanceStatsFragment = {
+  __typename?: 'InstanceStats';
+  suites: number;
+  tests: number;
+  pending: number;
+  passes: number;
+  failures: number;
+  skipped: number;
+  wallClockDuration: number;
+  wallClockStartedAt: string;
+  wallClockEndedAt: string;
+};
 
-export type AllInstanceStatsFragment = { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string };
+export type RunSummaryCompletionFragment = {
+  __typename?: 'RunCompletion';
+  completed: boolean;
+  inactivityTimeoutMs: Maybe<number>;
+};
 
-export type RunSummaryCompletionFragment = { __typename?: 'RunCompletion', completed: boolean, inactivityTimeoutMs: Maybe<number> };
+export type RunSummaryMetaFragment = {
+  __typename?: 'RunMeta';
+  ciBuildId: string;
+  projectId: string;
+  commit: Maybe<{
+    __typename?: 'Commit';
+    sha: Maybe<string>;
+    branch: Maybe<string>;
+    remoteOrigin: Maybe<string>;
+    message: Maybe<string>;
+    authorEmail: Maybe<string>;
+    authorName: Maybe<string>;
+  }>;
+};
 
-export type RunSummaryMetaFragment = { __typename?: 'RunMeta', ciBuildId: string, projectId: string, commit: Maybe<{ __typename?: 'Commit', sha: Maybe<string>, branch: Maybe<string>, remoteOrigin: Maybe<string>, message: Maybe<string>, authorEmail: Maybe<string>, authorName: Maybe<string> }> };
-
-export type RunSummarySpecFragment = { __typename?: 'RunSpec', claimedAt: Maybe<string>, results: Maybe<{ __typename?: 'InstanceResults', stats: (
-      { __typename?: 'InstanceStats' }
-      & AllInstanceStatsFragment
-    ) }> };
+export type RunSummarySpecFragment = {
+  __typename?: 'RunSpec';
+  claimedAt: Maybe<string>;
+  results: Maybe<{
+    __typename?: 'InstanceResults';
+    stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+  }>;
+};
 
 export type GetRunsFeedQueryVariables = Exact<{
   cursor: Maybe<Scalars['String']>;
   filters: Maybe<Array<Maybe<Filters>> | Maybe<Filters>>;
 }>;
 
-
-export type GetRunsFeedQuery = { __typename?: 'Query', runFeed: { __typename?: 'RunFeed', cursor: string, hasMore: boolean, runs: Array<{ __typename?: 'Run', runId: string, createdAt: string }> } };
+export type GetRunsFeedQuery = {
+  __typename?: 'Query';
+  runFeed: {
+    __typename?: 'RunFeed';
+    cursor: string;
+    hasMore: boolean;
+    runs: Array<{ __typename?: 'Run'; runId: string; createdAt: string }>;
+  };
+};
 
 export const AllInstanceStatsFragmentDoc = gql`
-    fragment AllInstanceStats on InstanceStats {
-  suites
-  tests
-  pending
-  passes
-  failures
-  skipped
-  suites
-  wallClockDuration
-  wallClockStartedAt
-  wallClockEndedAt
-}
-    `;
+  fragment AllInstanceStats on InstanceStats {
+    suites
+    tests
+    pending
+    passes
+    failures
+    skipped
+    suites
+    wallClockDuration
+    wallClockStartedAt
+    wallClockEndedAt
+  }
+`;
 export const RunDetailSpecFragmentDoc = gql`
-    fragment RunDetailSpec on RunSpec {
-  instanceId
-  spec
-  claimedAt
-  machineId
-  groupId
-  results {
-    error
-    tests {
-      ... on InstanceTest {
-        state
-      }
-      ... on InstanceTestV5 {
-        state
-        attempts {
-          state
-        }
-      }
-    }
-    stats {
-      ...AllInstanceStats
-    }
-  }
-}
-    ${AllInstanceStatsFragmentDoc}`;
-export const RunSummaryCompletionFragmentDoc = gql`
-    fragment RunSummaryCompletion on RunCompletion {
-  completed
-  inactivityTimeoutMs
-}
-    `;
-export const RunSummaryMetaFragmentDoc = gql`
-    fragment RunSummaryMeta on RunMeta {
-  ciBuildId
-  projectId
-  commit {
-    sha
-    branch
-    remoteOrigin
-    message
-    authorEmail
-    authorName
-  }
-}
-    `;
-export const RunSummarySpecFragmentDoc = gql`
-    fragment RunSummarySpec on RunSpec {
-  claimedAt
-  results {
-    stats {
-      ...AllInstanceStats
-    }
-  }
-}
-    ${AllInstanceStatsFragmentDoc}`;
-export const GetInstanceDocument = gql`
-    query getInstance($instanceId: ID!) {
-  instance(id: $instanceId) {
+  fragment RunDetailSpec on RunSpec {
     instanceId
-    runId
     spec
-    run {
-      runId
-      meta {
-        ciBuildId
-        projectId
-      }
-    }
+    claimedAt
+    machineId
+    groupId
     results {
       error
-      stats {
-        ...AllInstanceStats
-      }
       tests {
         ... on InstanceTest {
-          testId
-          title
           state
-          wallClockDuration
-          wallClockStartedAt
-          error
-          stack
         }
         ... on InstanceTestV5 {
-          testId
-          title
           state
-          displayError
           attempts {
             state
-            wallClockDuration
-            wallClockStartedAt
-            error {
-              name
-              message
-              stack
-            }
           }
         }
       }
-      screenshots {
-        testId
-        screenshotId
-        height
-        width
-        screenshotURL
+      stats {
+        ...AllInstanceStats
       }
-      cypressConfig {
-        video
-        videoUploadOnPasses
-      }
-      videoUrl
     }
   }
-}
-    ${AllInstanceStatsFragmentDoc}`;
+  ${AllInstanceStatsFragmentDoc}
+`;
+export const RunSummaryCompletionFragmentDoc = gql`
+  fragment RunSummaryCompletion on RunCompletion {
+    completed
+    inactivityTimeoutMs
+  }
+`;
+export const RunSummaryMetaFragmentDoc = gql`
+  fragment RunSummaryMeta on RunMeta {
+    ciBuildId
+    projectId
+    commit {
+      sha
+      branch
+      remoteOrigin
+      message
+      authorEmail
+      authorName
+    }
+  }
+`;
+export const RunSummarySpecFragmentDoc = gql`
+  fragment RunSummarySpec on RunSpec {
+    claimedAt
+    results {
+      stats {
+        ...AllInstanceStats
+      }
+    }
+  }
+  ${AllInstanceStatsFragmentDoc}
+`;
+export const GetInstanceDocument = gql`
+  query getInstance($instanceId: ID!) {
+    instance(id: $instanceId) {
+      instanceId
+      runId
+      spec
+      run {
+        runId
+        meta {
+          ciBuildId
+          projectId
+        }
+      }
+      results {
+        error
+        stats {
+          ...AllInstanceStats
+        }
+        tests {
+          ... on InstanceTest {
+            testId
+            title
+            state
+            wallClockDuration
+            wallClockStartedAt
+            error
+            stack
+          }
+          ... on InstanceTestV5 {
+            testId
+            title
+            state
+            displayError
+            attempts {
+              state
+              wallClockDuration
+              wallClockStartedAt
+              error {
+                name
+                message
+                stack
+              }
+            }
+          }
+        }
+        screenshots {
+          testId
+          screenshotId
+          height
+          width
+          screenshotURL
+        }
+        cypressConfig {
+          video
+          videoUploadOnPasses
+        }
+        videoUrl
+      }
+    }
+  }
+  ${AllInstanceStatsFragmentDoc}
+`;
 
 /**
  * __useGetInstanceQuery__
@@ -848,24 +1088,48 @@ export const GetInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetInstanceQuery(baseOptions: Apollo.QueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-        return Apollo.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
-      }
-export function useGetInstanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-          return Apollo.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, baseOptions);
-        }
-export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
-export type GetInstanceLazyQueryHookResult = ReturnType<typeof useGetInstanceLazyQuery>;
-export type GetInstanceQueryResult = Apollo.QueryResult<GetInstanceQuery, GetInstanceQueryVariables>;
-export const CreateProjectDocument = gql`
-    mutation createProject($project: CreateProjectInput!) {
-  createProject(project: $project) {
-    projectId
-    inactivityTimeoutSeconds
-  }
+export function useGetInstanceQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(
+    GetInstanceDocument,
+    baseOptions
+  );
 }
-    `;
-export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+export function useGetInstanceLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(
+    GetInstanceDocument,
+    baseOptions
+  );
+}
+export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
+export type GetInstanceLazyQueryHookResult = ReturnType<
+  typeof useGetInstanceLazyQuery
+>;
+export type GetInstanceQueryResult = Apollo.QueryResult<
+  GetInstanceQuery,
+  GetInstanceQueryVariables
+>;
+export const CreateProjectDocument = gql`
+  mutation createProject($project: CreateProjectInput!) {
+    createProject(project: $project) {
+      projectId
+      inactivityTimeoutSeconds
+    }
+  }
+`;
+export type CreateProjectMutationFn = Apollo.MutationFunction<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;
 
 /**
  * __useCreateProjectMutation__
@@ -884,22 +1148,40 @@ export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutat
  *   },
  * });
  */
-export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
-        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, baseOptions);
-      }
-export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
-export const DeleteProjectDocument = gql`
-    mutation deleteProject($projectId: ID!) {
-  deleteProject(projectId: $projectId) {
-    success
-    message
-    projectIds
-  }
+export function useCreateProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >(CreateProjectDocument, baseOptions);
 }
-    `;
-export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type CreateProjectMutationHookResult = ReturnType<
+  typeof useCreateProjectMutation
+>;
+export type CreateProjectMutationResult = Apollo.MutationResult<
+  CreateProjectMutation
+>;
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;
+export const DeleteProjectDocument = gql`
+  mutation deleteProject($projectId: ID!) {
+    deleteProject(projectId: $projectId) {
+      success
+      message
+      projectIds
+    }
+  }
+`;
+export type DeleteProjectMutationFn = Apollo.MutationFunction<
+  DeleteProjectMutation,
+  DeleteProjectMutationVariables
+>;
 
 /**
  * __useDeleteProjectMutation__
@@ -918,34 +1200,49 @@ export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutat
  *   },
  * });
  */
-export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
-        return Apollo.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
-      }
-export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
-export type DeleteProjectMutationResult = Apollo.MutationResult<DeleteProjectMutation>;
-export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export function useDeleteProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteProjectMutation,
+    DeleteProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    DeleteProjectMutation,
+    DeleteProjectMutationVariables
+  >(DeleteProjectDocument, baseOptions);
+}
+export type DeleteProjectMutationHookResult = ReturnType<
+  typeof useDeleteProjectMutation
+>;
+export type DeleteProjectMutationResult = Apollo.MutationResult<
+  DeleteProjectMutation
+>;
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<
+  DeleteProjectMutation,
+  DeleteProjectMutationVariables
+>;
 export const GetProjectDocument = gql`
-    query getProject($projectId: ID!) {
-  project(id: $projectId) {
-    projectId
-    inactivityTimeoutSeconds
-    hooks {
-      hookId
-      url
-      headers
-      hookEvents
-      hookType
-      slackResultFilter
-      slackBranchFilter
-      githubContext
-      githubToken
-      bitbucketUsername
-      bitbucketToken
-      bitbucketBuildName
+  query getProject($projectId: ID!) {
+    project(id: $projectId) {
+      projectId
+      inactivityTimeoutSeconds
+      hooks {
+        hookId
+        url
+        headers
+        hookEvents
+        hookType
+        slackResultFilter
+        slackBranchFilter
+        githubContext
+        githubToken
+        bitbucketUsername
+        bitbucketToken
+        bitbucketBuildName
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetProjectQuery__
@@ -963,22 +1260,43 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-        return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
-      }
-export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-          return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
-        }
-export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
-export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
-export type GetProjectQueryResult = Apollo.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
-export const GetProjectsDocument = gql`
-    query getProjects($orderDirection: OrderingOptions, $filters: [Filters]) {
-  projects(orderDirection: $orderDirection, filters: $filters) {
-    projectId
-  }
+export function useGetProjectQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetProjectQuery,
+    GetProjectQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(
+    GetProjectDocument,
+    baseOptions
+  );
 }
-    `;
+export function useGetProjectLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProjectQuery,
+    GetProjectQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(
+    GetProjectDocument,
+    baseOptions
+  );
+}
+export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
+export type GetProjectLazyQueryHookResult = ReturnType<
+  typeof useGetProjectLazyQuery
+>;
+export type GetProjectQueryResult = Apollo.QueryResult<
+  GetProjectQuery,
+  GetProjectQueryVariables
+>;
+export const GetProjectsDocument = gql`
+  query getProjects($orderDirection: OrderingOptions, $filters: [Filters]) {
+    projects(orderDirection: $orderDirection, filters: $filters) {
+      projectId
+    }
+  }
+`;
 
 /**
  * __useGetProjectsQuery__
@@ -997,28 +1315,52 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(baseOptions?: Apollo.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-        return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
-      }
-export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-          return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
-        }
-export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
-export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
-export type GetProjectsQueryResult = Apollo.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
-export const CreateBitbucketHookDocument = gql`
-    mutation createBitbucketHook($input: CreateBitbucketHookInput!) {
-  createBitbucketHook(input: $input) {
-    projectId
-    hookId
-    hookType
-    url
-    bitbucketUsername
-    bitbucketBuildName
-  }
+export function useGetProjectsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetProjectsQuery,
+    GetProjectsQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(
+    GetProjectsDocument,
+    baseOptions
+  );
 }
-    `;
-export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>;
+export function useGetProjectsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProjectsQuery,
+    GetProjectsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(
+    GetProjectsDocument,
+    baseOptions
+  );
+}
+export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
+export type GetProjectsLazyQueryHookResult = ReturnType<
+  typeof useGetProjectsLazyQuery
+>;
+export type GetProjectsQueryResult = Apollo.QueryResult<
+  GetProjectsQuery,
+  GetProjectsQueryVariables
+>;
+export const CreateBitbucketHookDocument = gql`
+  mutation createBitbucketHook($input: CreateBitbucketHookInput!) {
+    createBitbucketHook(input: $input) {
+      projectId
+      hookId
+      hookType
+      url
+      bitbucketUsername
+      bitbucketBuildName
+    }
+  }
+`;
+export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<
+  CreateBitbucketHookMutation,
+  CreateBitbucketHookMutationVariables
+>;
 
 /**
  * __useCreateBitbucketHookMutation__
@@ -1037,24 +1379,42 @@ export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<CreateBitbuc
  *   },
  * });
  */
-export function useCreateBitbucketHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>) {
-        return Apollo.useMutation<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>(CreateBitbucketHookDocument, baseOptions);
-      }
-export type CreateBitbucketHookMutationHookResult = ReturnType<typeof useCreateBitbucketHookMutation>;
-export type CreateBitbucketHookMutationResult = Apollo.MutationResult<CreateBitbucketHookMutation>;
-export type CreateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>;
-export const CreateGenericHookDocument = gql`
-    mutation createGenericHook($input: CreateGenericHookInput!) {
-  createGenericHook(input: $input) {
-    hookId
-    hookType
-    url
-    hookEvents
-    headers
-  }
+export function useCreateBitbucketHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateBitbucketHookMutation,
+    CreateBitbucketHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateBitbucketHookMutation,
+    CreateBitbucketHookMutationVariables
+  >(CreateBitbucketHookDocument, baseOptions);
 }
-    `;
-export type CreateGenericHookMutationFn = Apollo.MutationFunction<CreateGenericHookMutation, CreateGenericHookMutationVariables>;
+export type CreateBitbucketHookMutationHookResult = ReturnType<
+  typeof useCreateBitbucketHookMutation
+>;
+export type CreateBitbucketHookMutationResult = Apollo.MutationResult<
+  CreateBitbucketHookMutation
+>;
+export type CreateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateBitbucketHookMutation,
+  CreateBitbucketHookMutationVariables
+>;
+export const CreateGenericHookDocument = gql`
+  mutation createGenericHook($input: CreateGenericHookInput!) {
+    createGenericHook(input: $input) {
+      hookId
+      hookType
+      url
+      hookEvents
+      headers
+    }
+  }
+`;
+export type CreateGenericHookMutationFn = Apollo.MutationFunction<
+  CreateGenericHookMutation,
+  CreateGenericHookMutationVariables
+>;
 
 /**
  * __useCreateGenericHookMutation__
@@ -1073,25 +1433,43 @@ export type CreateGenericHookMutationFn = Apollo.MutationFunction<CreateGenericH
  *   },
  * });
  */
-export function useCreateGenericHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateGenericHookMutation, CreateGenericHookMutationVariables>) {
-        return Apollo.useMutation<CreateGenericHookMutation, CreateGenericHookMutationVariables>(CreateGenericHookDocument, baseOptions);
-      }
-export type CreateGenericHookMutationHookResult = ReturnType<typeof useCreateGenericHookMutation>;
-export type CreateGenericHookMutationResult = Apollo.MutationResult<CreateGenericHookMutation>;
-export type CreateGenericHookMutationOptions = Apollo.BaseMutationOptions<CreateGenericHookMutation, CreateGenericHookMutationVariables>;
-export const CreateGithubHookDocument = gql`
-    mutation createGithubHook($input: CreateGithubHookInput!) {
-  createGithubHook(input: $input) {
-    projectId
-    hookId
-    hookType
-    url
-    githubToken
-    githubContext
-  }
+export function useCreateGenericHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateGenericHookMutation,
+    CreateGenericHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateGenericHookMutation,
+    CreateGenericHookMutationVariables
+  >(CreateGenericHookDocument, baseOptions);
 }
-    `;
-export type CreateGithubHookMutationFn = Apollo.MutationFunction<CreateGithubHookMutation, CreateGithubHookMutationVariables>;
+export type CreateGenericHookMutationHookResult = ReturnType<
+  typeof useCreateGenericHookMutation
+>;
+export type CreateGenericHookMutationResult = Apollo.MutationResult<
+  CreateGenericHookMutation
+>;
+export type CreateGenericHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateGenericHookMutation,
+  CreateGenericHookMutationVariables
+>;
+export const CreateGithubHookDocument = gql`
+  mutation createGithubHook($input: CreateGithubHookInput!) {
+    createGithubHook(input: $input) {
+      projectId
+      hookId
+      hookType
+      url
+      githubToken
+      githubContext
+    }
+  }
+`;
+export type CreateGithubHookMutationFn = Apollo.MutationFunction<
+  CreateGithubHookMutation,
+  CreateGithubHookMutationVariables
+>;
 
 /**
  * __useCreateGithubHookMutation__
@@ -1110,25 +1488,43 @@ export type CreateGithubHookMutationFn = Apollo.MutationFunction<CreateGithubHoo
  *   },
  * });
  */
-export function useCreateGithubHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateGithubHookMutation, CreateGithubHookMutationVariables>) {
-        return Apollo.useMutation<CreateGithubHookMutation, CreateGithubHookMutationVariables>(CreateGithubHookDocument, baseOptions);
-      }
-export type CreateGithubHookMutationHookResult = ReturnType<typeof useCreateGithubHookMutation>;
-export type CreateGithubHookMutationResult = Apollo.MutationResult<CreateGithubHookMutation>;
-export type CreateGithubHookMutationOptions = Apollo.BaseMutationOptions<CreateGithubHookMutation, CreateGithubHookMutationVariables>;
-export const CreateSlackHookDocument = gql`
-    mutation createSlackHook($input: CreateSlackHookInput!) {
-  createSlackHook(input: $input) {
-    hookId
-    hookType
-    url
-    hookEvents
-    slackResultFilter
-    slackBranchFilter
-  }
+export function useCreateGithubHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateGithubHookMutation,
+    CreateGithubHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateGithubHookMutation,
+    CreateGithubHookMutationVariables
+  >(CreateGithubHookDocument, baseOptions);
 }
-    `;
-export type CreateSlackHookMutationFn = Apollo.MutationFunction<CreateSlackHookMutation, CreateSlackHookMutationVariables>;
+export type CreateGithubHookMutationHookResult = ReturnType<
+  typeof useCreateGithubHookMutation
+>;
+export type CreateGithubHookMutationResult = Apollo.MutationResult<
+  CreateGithubHookMutation
+>;
+export type CreateGithubHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateGithubHookMutation,
+  CreateGithubHookMutationVariables
+>;
+export const CreateSlackHookDocument = gql`
+  mutation createSlackHook($input: CreateSlackHookInput!) {
+    createSlackHook(input: $input) {
+      hookId
+      hookType
+      url
+      hookEvents
+      slackResultFilter
+      slackBranchFilter
+    }
+  }
+`;
+export type CreateSlackHookMutationFn = Apollo.MutationFunction<
+  CreateSlackHookMutation,
+  CreateSlackHookMutationVariables
+>;
 
 /**
  * __useCreateSlackHookMutation__
@@ -1147,21 +1543,39 @@ export type CreateSlackHookMutationFn = Apollo.MutationFunction<CreateSlackHookM
  *   },
  * });
  */
-export function useCreateSlackHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateSlackHookMutation, CreateSlackHookMutationVariables>) {
-        return Apollo.useMutation<CreateSlackHookMutation, CreateSlackHookMutationVariables>(CreateSlackHookDocument, baseOptions);
-      }
-export type CreateSlackHookMutationHookResult = ReturnType<typeof useCreateSlackHookMutation>;
-export type CreateSlackHookMutationResult = Apollo.MutationResult<CreateSlackHookMutation>;
-export type CreateSlackHookMutationOptions = Apollo.BaseMutationOptions<CreateSlackHookMutation, CreateSlackHookMutationVariables>;
-export const DeleteHookDocument = gql`
-    mutation deleteHook($input: DeleteHookInput!) {
-  deleteHook(input: $input) {
-    hookId
-    projectId
-  }
+export function useCreateSlackHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateSlackHookMutation,
+    CreateSlackHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateSlackHookMutation,
+    CreateSlackHookMutationVariables
+  >(CreateSlackHookDocument, baseOptions);
 }
-    `;
-export type DeleteHookMutationFn = Apollo.MutationFunction<DeleteHookMutation, DeleteHookMutationVariables>;
+export type CreateSlackHookMutationHookResult = ReturnType<
+  typeof useCreateSlackHookMutation
+>;
+export type CreateSlackHookMutationResult = Apollo.MutationResult<
+  CreateSlackHookMutation
+>;
+export type CreateSlackHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateSlackHookMutation,
+  CreateSlackHookMutationVariables
+>;
+export const DeleteHookDocument = gql`
+  mutation deleteHook($input: DeleteHookInput!) {
+    deleteHook(input: $input) {
+      hookId
+      projectId
+    }
+  }
+`;
+export type DeleteHookMutationFn = Apollo.MutationFunction<
+  DeleteHookMutation,
+  DeleteHookMutationVariables
+>;
 
 /**
  * __useDeleteHookMutation__
@@ -1180,20 +1594,38 @@ export type DeleteHookMutationFn = Apollo.MutationFunction<DeleteHookMutation, D
  *   },
  * });
  */
-export function useDeleteHookMutation(baseOptions?: Apollo.MutationHookOptions<DeleteHookMutation, DeleteHookMutationVariables>) {
-        return Apollo.useMutation<DeleteHookMutation, DeleteHookMutationVariables>(DeleteHookDocument, baseOptions);
-      }
-export type DeleteHookMutationHookResult = ReturnType<typeof useDeleteHookMutation>;
-export type DeleteHookMutationResult = Apollo.MutationResult<DeleteHookMutation>;
-export type DeleteHookMutationOptions = Apollo.BaseMutationOptions<DeleteHookMutation, DeleteHookMutationVariables>;
-export const UpdateBitbucketHookDocument = gql`
-    mutation updateBitbucketHook($input: UpdateBitbucketHookInput!) {
-  updateBitbucketHook(input: $input) {
-    hookId
-  }
+export function useDeleteHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteHookMutation,
+    DeleteHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<DeleteHookMutation, DeleteHookMutationVariables>(
+    DeleteHookDocument,
+    baseOptions
+  );
 }
-    `;
-export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>;
+export type DeleteHookMutationHookResult = ReturnType<
+  typeof useDeleteHookMutation
+>;
+export type DeleteHookMutationResult = Apollo.MutationResult<
+  DeleteHookMutation
+>;
+export type DeleteHookMutationOptions = Apollo.BaseMutationOptions<
+  DeleteHookMutation,
+  DeleteHookMutationVariables
+>;
+export const UpdateBitbucketHookDocument = gql`
+  mutation updateBitbucketHook($input: UpdateBitbucketHookInput!) {
+    updateBitbucketHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<
+  UpdateBitbucketHookMutation,
+  UpdateBitbucketHookMutationVariables
+>;
 
 /**
  * __useUpdateBitbucketHookMutation__
@@ -1212,20 +1644,38 @@ export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<UpdateBitbuc
  *   },
  * });
  */
-export function useUpdateBitbucketHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>) {
-        return Apollo.useMutation<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>(UpdateBitbucketHookDocument, baseOptions);
-      }
-export type UpdateBitbucketHookMutationHookResult = ReturnType<typeof useUpdateBitbucketHookMutation>;
-export type UpdateBitbucketHookMutationResult = Apollo.MutationResult<UpdateBitbucketHookMutation>;
-export type UpdateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>;
-export const UpdateGenericHookDocument = gql`
-    mutation updateGenericHook($input: UpdateGenericHookInput!) {
-  updateGenericHook(input: $input) {
-    hookId
-  }
+export function useUpdateBitbucketHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateBitbucketHookMutation,
+    UpdateBitbucketHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateBitbucketHookMutation,
+    UpdateBitbucketHookMutationVariables
+  >(UpdateBitbucketHookDocument, baseOptions);
 }
-    `;
-export type UpdateGenericHookMutationFn = Apollo.MutationFunction<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>;
+export type UpdateBitbucketHookMutationHookResult = ReturnType<
+  typeof useUpdateBitbucketHookMutation
+>;
+export type UpdateBitbucketHookMutationResult = Apollo.MutationResult<
+  UpdateBitbucketHookMutation
+>;
+export type UpdateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateBitbucketHookMutation,
+  UpdateBitbucketHookMutationVariables
+>;
+export const UpdateGenericHookDocument = gql`
+  mutation updateGenericHook($input: UpdateGenericHookInput!) {
+    updateGenericHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateGenericHookMutationFn = Apollo.MutationFunction<
+  UpdateGenericHookMutation,
+  UpdateGenericHookMutationVariables
+>;
 
 /**
  * __useUpdateGenericHookMutation__
@@ -1244,20 +1694,38 @@ export type UpdateGenericHookMutationFn = Apollo.MutationFunction<UpdateGenericH
  *   },
  * });
  */
-export function useUpdateGenericHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>) {
-        return Apollo.useMutation<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>(UpdateGenericHookDocument, baseOptions);
-      }
-export type UpdateGenericHookMutationHookResult = ReturnType<typeof useUpdateGenericHookMutation>;
-export type UpdateGenericHookMutationResult = Apollo.MutationResult<UpdateGenericHookMutation>;
-export type UpdateGenericHookMutationOptions = Apollo.BaseMutationOptions<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>;
-export const UpdateGithubHookDocument = gql`
-    mutation updateGithubHook($input: UpdateGithubHookInput!) {
-  updateGithubHook(input: $input) {
-    hookId
-  }
+export function useUpdateGenericHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateGenericHookMutation,
+    UpdateGenericHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateGenericHookMutation,
+    UpdateGenericHookMutationVariables
+  >(UpdateGenericHookDocument, baseOptions);
 }
-    `;
-export type UpdateGithubHookMutationFn = Apollo.MutationFunction<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>;
+export type UpdateGenericHookMutationHookResult = ReturnType<
+  typeof useUpdateGenericHookMutation
+>;
+export type UpdateGenericHookMutationResult = Apollo.MutationResult<
+  UpdateGenericHookMutation
+>;
+export type UpdateGenericHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateGenericHookMutation,
+  UpdateGenericHookMutationVariables
+>;
+export const UpdateGithubHookDocument = gql`
+  mutation updateGithubHook($input: UpdateGithubHookInput!) {
+    updateGithubHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateGithubHookMutationFn = Apollo.MutationFunction<
+  UpdateGithubHookMutation,
+  UpdateGithubHookMutationVariables
+>;
 
 /**
  * __useUpdateGithubHookMutation__
@@ -1276,20 +1744,38 @@ export type UpdateGithubHookMutationFn = Apollo.MutationFunction<UpdateGithubHoo
  *   },
  * });
  */
-export function useUpdateGithubHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>) {
-        return Apollo.useMutation<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>(UpdateGithubHookDocument, baseOptions);
-      }
-export type UpdateGithubHookMutationHookResult = ReturnType<typeof useUpdateGithubHookMutation>;
-export type UpdateGithubHookMutationResult = Apollo.MutationResult<UpdateGithubHookMutation>;
-export type UpdateGithubHookMutationOptions = Apollo.BaseMutationOptions<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>;
-export const UpdateSlackHookDocument = gql`
-    mutation updateSlackHook($input: UpdateSlackHookInput!) {
-  updateSlackHook(input: $input) {
-    hookId
-  }
+export function useUpdateGithubHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateGithubHookMutation,
+    UpdateGithubHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateGithubHookMutation,
+    UpdateGithubHookMutationVariables
+  >(UpdateGithubHookDocument, baseOptions);
 }
-    `;
-export type UpdateSlackHookMutationFn = Apollo.MutationFunction<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>;
+export type UpdateGithubHookMutationHookResult = ReturnType<
+  typeof useUpdateGithubHookMutation
+>;
+export type UpdateGithubHookMutationResult = Apollo.MutationResult<
+  UpdateGithubHookMutation
+>;
+export type UpdateGithubHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateGithubHookMutation,
+  UpdateGithubHookMutationVariables
+>;
+export const UpdateSlackHookDocument = gql`
+  mutation updateSlackHook($input: UpdateSlackHookInput!) {
+    updateSlackHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateSlackHookMutationFn = Apollo.MutationFunction<
+  UpdateSlackHookMutation,
+  UpdateSlackHookMutationVariables
+>;
 
 /**
  * __useUpdateSlackHookMutation__
@@ -1308,21 +1794,39 @@ export type UpdateSlackHookMutationFn = Apollo.MutationFunction<UpdateSlackHookM
  *   },
  * });
  */
-export function useUpdateSlackHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>) {
-        return Apollo.useMutation<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>(UpdateSlackHookDocument, baseOptions);
-      }
-export type UpdateSlackHookMutationHookResult = ReturnType<typeof useUpdateSlackHookMutation>;
-export type UpdateSlackHookMutationResult = Apollo.MutationResult<UpdateSlackHookMutation>;
-export type UpdateSlackHookMutationOptions = Apollo.BaseMutationOptions<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>;
-export const UpdateProjectDocument = gql`
-    mutation updateProject($input: UpdateProjectInput!) {
-  updateProject(input: $input) {
-    projectId
-    inactivityTimeoutSeconds
-  }
+export function useUpdateSlackHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateSlackHookMutation,
+    UpdateSlackHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateSlackHookMutation,
+    UpdateSlackHookMutationVariables
+  >(UpdateSlackHookDocument, baseOptions);
 }
-    `;
-export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateSlackHookMutationHookResult = ReturnType<
+  typeof useUpdateSlackHookMutation
+>;
+export type UpdateSlackHookMutationResult = Apollo.MutationResult<
+  UpdateSlackHookMutation
+>;
+export type UpdateSlackHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateSlackHookMutation,
+  UpdateSlackHookMutationVariables
+>;
+export const UpdateProjectDocument = gql`
+  mutation updateProject($input: UpdateProjectInput!) {
+    updateProject(input: $input) {
+      projectId
+      inactivityTimeoutSeconds
+    }
+  }
+`;
+export type UpdateProjectMutationFn = Apollo.MutationFunction<
+  UpdateProjectMutation,
+  UpdateProjectMutationVariables
+>;
 
 /**
  * __useUpdateProjectMutation__
@@ -1341,22 +1845,40 @@ export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutat
  *   },
  * });
  */
-export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
-        return Apollo.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, baseOptions);
-      }
-export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
-export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
-export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
-export const DeleteRunDocument = gql`
-    mutation deleteRun($runId: ID!) {
-  deleteRun(runId: $runId) {
-    success
-    message
-    runIds
-  }
+export function useUpdateProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateProjectMutation,
+    UpdateProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateProjectMutation,
+    UpdateProjectMutationVariables
+  >(UpdateProjectDocument, baseOptions);
 }
-    `;
-export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
+export type UpdateProjectMutationHookResult = ReturnType<
+  typeof useUpdateProjectMutation
+>;
+export type UpdateProjectMutationResult = Apollo.MutationResult<
+  UpdateProjectMutation
+>;
+export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<
+  UpdateProjectMutation,
+  UpdateProjectMutationVariables
+>;
+export const DeleteRunDocument = gql`
+  mutation deleteRun($runId: ID!) {
+    deleteRun(runId: $runId) {
+      success
+      message
+      runIds
+    }
+  }
+`;
+export type DeleteRunMutationFn = Apollo.MutationFunction<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
 
 /**
  * __useDeleteRunMutation__
@@ -1375,21 +1897,34 @@ export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, Del
  *   },
  * });
  */
-export function useDeleteRunMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
-        return Apollo.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, baseOptions);
-      }
-export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
-export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutation>;
-export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
-export const GetSpecStatsDocument = gql`
-    query getSpecStats($spec: String!) {
-  specStats(spec: $spec) {
-    spec
-    count
-    avgWallClockDuration
-  }
+export function useDeleteRunMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteRunMutation,
+    DeleteRunMutationVariables
+  >
+) {
+  return Apollo.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(
+    DeleteRunDocument,
+    baseOptions
+  );
 }
-    `;
+export type DeleteRunMutationHookResult = ReturnType<
+  typeof useDeleteRunMutation
+>;
+export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutation>;
+export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
+export const GetSpecStatsDocument = gql`
+  query getSpecStats($spec: String!) {
+    specStats(spec: $spec) {
+      spec
+      count
+      avgWallClockDuration
+    }
+  }
+`;
 
 /**
  * __useGetSpecStatsQuery__
@@ -1407,34 +1942,110 @@ export const GetSpecStatsDocument = gql`
  *   },
  * });
  */
-export function useGetSpecStatsQuery(baseOptions: Apollo.QueryHookOptions<GetSpecStatsQuery, GetSpecStatsQueryVariables>) {
-        return Apollo.useQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(GetSpecStatsDocument, baseOptions);
-      }
-export function useGetSpecStatsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSpecStatsQuery, GetSpecStatsQueryVariables>) {
-          return Apollo.useLazyQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(GetSpecStatsDocument, baseOptions);
-        }
-export type GetSpecStatsQueryHookResult = ReturnType<typeof useGetSpecStatsQuery>;
-export type GetSpecStatsLazyQueryHookResult = ReturnType<typeof useGetSpecStatsLazyQuery>;
-export type GetSpecStatsQueryResult = Apollo.QueryResult<GetSpecStatsQuery, GetSpecStatsQueryVariables>;
-export const GetRunDocument = gql`
-    query getRun($runId: ID!) {
-  run(id: $runId) {
-    runId
-    createdAt
-    completion {
-      ...RunSummaryCompletion
-    }
-    meta {
-      ...RunSummaryMeta
-    }
-    specs {
-      ...RunDetailSpec
+export function useGetSpecStatsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetSpecStatsQuery,
+    GetSpecStatsQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(
+    GetSpecStatsDocument,
+    baseOptions
+  );
+}
+export function useGetSpecStatsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetSpecStatsQuery,
+    GetSpecStatsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(
+    GetSpecStatsDocument,
+    baseOptions
+  );
+}
+export type GetSpecStatsQueryHookResult = ReturnType<
+  typeof useGetSpecStatsQuery
+>;
+export type GetSpecStatsLazyQueryHookResult = ReturnType<
+  typeof useGetSpecStatsLazyQuery
+>;
+export type GetSpecStatsQueryResult = Apollo.QueryResult<
+  GetSpecStatsQuery,
+  GetSpecStatsQueryVariables
+>;
+export const ResetInstanceDocument = gql`
+  mutation resetInstance($instanceId: ID!) {
+    resetInstance(instanceId: $instanceId) {
+      success
+      message
+      instanceId
     }
   }
+`;
+export type ResetInstanceMutationFn = Apollo.MutationFunction<
+  ResetInstanceMutation,
+  ResetInstanceMutationVariables
+>;
+
+/**
+ * __useResetInstanceMutation__
+ *
+ * To run a mutation, you first call `useResetInstanceMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useResetInstanceMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [resetInstanceMutation, { data, loading, error }] = useResetInstanceMutation({
+ *   variables: {
+ *      instanceId: // value for 'instanceId'
+ *   },
+ * });
+ */
+export function useResetInstanceMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    ResetInstanceMutation,
+    ResetInstanceMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    ResetInstanceMutation,
+    ResetInstanceMutationVariables
+  >(ResetInstanceDocument, baseOptions);
 }
-    ${RunSummaryCompletionFragmentDoc}
-${RunSummaryMetaFragmentDoc}
-${RunDetailSpecFragmentDoc}`;
+export type ResetInstanceMutationHookResult = ReturnType<
+  typeof useResetInstanceMutation
+>;
+export type ResetInstanceMutationResult = Apollo.MutationResult<
+  ResetInstanceMutation
+>;
+export type ResetInstanceMutationOptions = Apollo.BaseMutationOptions<
+  ResetInstanceMutation,
+  ResetInstanceMutationVariables
+>;
+export const GetRunDocument = gql`
+  query getRun($runId: ID!) {
+    run(id: $runId) {
+      runId
+      createdAt
+      completion {
+        ...RunSummaryCompletion
+      }
+      meta {
+        ...RunSummaryMeta
+      }
+      specs {
+        ...RunDetailSpec
+      }
+    }
+  }
+  ${RunSummaryCompletionFragmentDoc}
+  ${RunSummaryMetaFragmentDoc}
+  ${RunDetailSpecFragmentDoc}
+`;
 
 /**
  * __useGetRunQuery__
@@ -1452,34 +2063,48 @@ ${RunDetailSpecFragmentDoc}`;
  *   },
  * });
  */
-export function useGetRunQuery(baseOptions: Apollo.QueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-        return Apollo.useQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
-      }
-export function useGetRunLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-          return Apollo.useLazyQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, baseOptions);
-        }
+export function useGetRunQuery(
+  baseOptions: Apollo.QueryHookOptions<GetRunQuery, GetRunQueryVariables>
+) {
+  return Apollo.useQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
+}
+export function useGetRunLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>
+) {
+  return Apollo.useLazyQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
+}
 export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
 export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
-export type GetRunQueryResult = Apollo.QueryResult<GetRunQuery, GetRunQueryVariables>;
+export type GetRunQueryResult = Apollo.QueryResult<
+  GetRunQuery,
+  GetRunQueryVariables
+>;
 export const GetRunSummaryDocument = gql`
-    query getRunSummary($runId: ID!) {
-  run(id: $runId) {
-    runId
-    createdAt
-    meta {
-      ...RunSummaryMeta
-    }
-    completion {
-      ...RunSummaryCompletion
-    }
-    specs {
-      ...RunSummarySpec
+  query getRunSummary($runId: ID!) {
+    run(id: $runId) {
+      runId
+      createdAt
+      meta {
+        ...RunSummaryMeta
+      }
+      completion {
+        ...RunSummaryCompletion
+      }
+      specs {
+        ...RunSummarySpec
+      }
     }
   }
-}
-    ${RunSummaryMetaFragmentDoc}
-${RunSummaryCompletionFragmentDoc}
-${RunSummarySpecFragmentDoc}`;
+  ${RunSummaryMetaFragmentDoc}
+  ${RunSummaryCompletionFragmentDoc}
+  ${RunSummarySpecFragmentDoc}
+`;
 
 /**
  * __useGetRunSummaryQuery__
@@ -1497,27 +2122,50 @@ ${RunSummarySpecFragmentDoc}`;
  *   },
  * });
  */
-export function useGetRunSummaryQuery(baseOptions: Apollo.QueryHookOptions<GetRunSummaryQuery, GetRunSummaryQueryVariables>) {
-        return Apollo.useQuery<GetRunSummaryQuery, GetRunSummaryQueryVariables>(GetRunSummaryDocument, baseOptions);
-      }
-export function useGetRunSummaryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRunSummaryQuery, GetRunSummaryQueryVariables>) {
-          return Apollo.useLazyQuery<GetRunSummaryQuery, GetRunSummaryQueryVariables>(GetRunSummaryDocument, baseOptions);
-        }
-export type GetRunSummaryQueryHookResult = ReturnType<typeof useGetRunSummaryQuery>;
-export type GetRunSummaryLazyQueryHookResult = ReturnType<typeof useGetRunSummaryLazyQuery>;
-export type GetRunSummaryQueryResult = Apollo.QueryResult<GetRunSummaryQuery, GetRunSummaryQueryVariables>;
+export function useGetRunSummaryQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetRunSummaryQuery,
+    GetRunSummaryQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetRunSummaryQuery, GetRunSummaryQueryVariables>(
+    GetRunSummaryDocument,
+    baseOptions
+  );
+}
+export function useGetRunSummaryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetRunSummaryQuery,
+    GetRunSummaryQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetRunSummaryQuery, GetRunSummaryQueryVariables>(
+    GetRunSummaryDocument,
+    baseOptions
+  );
+}
+export type GetRunSummaryQueryHookResult = ReturnType<
+  typeof useGetRunSummaryQuery
+>;
+export type GetRunSummaryLazyQueryHookResult = ReturnType<
+  typeof useGetRunSummaryLazyQuery
+>;
+export type GetRunSummaryQueryResult = Apollo.QueryResult<
+  GetRunSummaryQuery,
+  GetRunSummaryQueryVariables
+>;
 export const GetRunsFeedDocument = gql`
-    query getRunsFeed($cursor: String, $filters: [Filters]) {
-  runFeed(cursor: $cursor, filters: $filters) {
-    cursor
-    hasMore
-    runs {
-      runId
-      createdAt
+  query getRunsFeed($cursor: String, $filters: [Filters]) {
+    runFeed(cursor: $cursor, filters: $filters) {
+      cursor
+      hasMore
+      runs {
+        runId
+        createdAt
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetRunsFeedQuery__
@@ -1536,28 +2184,45 @@ export const GetRunsFeedDocument = gql`
  *   },
  * });
  */
-export function useGetRunsFeedQuery(baseOptions?: Apollo.QueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-        return Apollo.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
-      }
-export function useGetRunsFeedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-          return Apollo.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, baseOptions);
-        }
+export function useGetRunsFeedQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
+    GetRunsFeedDocument,
+    baseOptions
+  );
+}
+export function useGetRunsFeedLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
+    GetRunsFeedDocument,
+    baseOptions
+  );
+}
 export type GetRunsFeedQueryHookResult = ReturnType<typeof useGetRunsFeedQuery>;
-export type GetRunsFeedLazyQueryHookResult = ReturnType<typeof useGetRunsFeedLazyQuery>;
-export type GetRunsFeedQueryResult = Apollo.QueryResult<GetRunsFeedQuery, GetRunsFeedQueryVariables>;
+export type GetRunsFeedLazyQueryHookResult = ReturnType<
+  typeof useGetRunsFeedLazyQuery
+>;
+export type GetRunsFeedQueryResult = Apollo.QueryResult<
+  GetRunsFeedQuery,
+  GetRunsFeedQueryVariables
+>;
 
-      export interface PossibleTypesResultData {
-        possibleTypes: {
-          [key: string]: string[]
-        }
-      }
-      const result: PossibleTypesResultData = {
-  "possibleTypes": {
-    "InstanceTestUnion": [
-      "InstanceTest",
-      "InstanceTestV5"
-    ]
-  }
+export interface PossibleTypesResultData {
+  possibleTypes: {
+    [key: string]: string[];
+  };
+}
+const result: PossibleTypesResultData = {
+  possibleTypes: {
+    InstanceTestUnion: ['InstanceTest', 'InstanceTestV5'],
+  },
 };
-      export default result;
-    
+export default result;

--- a/packages/dashboard/src/run/runDetails/details.tsx
+++ b/packages/dashboard/src/run/runDetails/details.tsx
@@ -15,6 +15,7 @@ import {
 } from '@src/generated/graphql';
 import { useHideSuccessfulSpecs } from '@src/hooks/';
 import { getSecondsDuration } from '@src/lib/duration';
+import { ResetInstanceButton } from '@src/run/runDetails/resetInstance/resetInstanceButton';
 import {
   Cell,
   DataTable,
@@ -135,6 +136,12 @@ export function RunDetails({ run }: { run: NonNullable<GetRunQuery['run']> }) {
                 sortable: false,
                 render: getSkippedCell,
               },
+              {
+                name: 'actions',
+                header: 'Actions',
+                sortable: false,
+                render: getActionsCell(run),
+              },
             ]}
           />
         </VFlow>
@@ -142,6 +149,18 @@ export function RunDetails({ run }: { run: NonNullable<GetRunQuery['run']> }) {
     </Grid>
   );
 }
+
+const getActionsCell = (run: NonNullable<GetRunQuery['run']>) => {
+  const getAction = (spec: RunDetailSpecFragment) => {
+    return spec.claimedAt ? (
+      <ResetInstanceButton
+        instanceId={spec.instanceId ?? 0}
+        runId={run.runId}
+      />
+    ) : null;
+  };
+  return getAction;
+};
 
 const getPassesCell = (spec: RunDetailSpecFragment) => {
   return <TestSuccessBadge value={spec.results?.stats?.passes ?? 0} />;

--- a/packages/dashboard/src/run/runDetails/resetInstance/resetInstance.graphql
+++ b/packages/dashboard/src/run/runDetails/resetInstance/resetInstance.graphql
@@ -1,0 +1,7 @@
+mutation resetInstance($instanceId: ID!) {
+  resetInstance(instanceId: $instanceId) {
+    success
+    message
+    instanceId
+  }
+}

--- a/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
+++ b/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
@@ -1,0 +1,131 @@
+import {
+  GetRunDocument,
+  useResetInstanceMutation,
+} from '@src/generated/graphql';
+import { useAsync } from '@src/hooks/';
+import {
+  Alert,
+  Button,
+  Heading,
+  HFlow,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  Text,
+} from 'bold-ui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouteMatch } from 'react-router-dom';
+
+export const ResetInstanceButton = ({
+  instanceId,
+  runId,
+}: {
+  instanceId: string;
+  runId: string;
+}) => {
+  const {
+    params: { projectId },
+  } = useRouteMatch<{ projectId: string }>();
+
+  const [resetInstance] = useResetInstanceMutation({
+    variables: {
+      instanceId: instanceId,
+    },
+    refetchQueries: [
+      {
+        query: GetRunDocument,
+        variables: {
+          runId: runId,
+        },
+      },
+    ],
+  });
+
+  const [startDeleteInstance, deleting, deleteResult, deleteError] = useAsync(
+    resetInstance
+  );
+  const [shouldShowModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (!deleteResult) {
+      return;
+    }
+    setShowModal(false);
+  }, [deleteResult]);
+
+  const deleteAction = useCallback(
+    (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      console.log('deleting here');
+      startDeleteInstance();
+    },
+    [startDeleteInstance]
+  );
+
+  return (
+    <>
+      <Modal
+        size="small"
+        onClose={() => setShowModal(false)}
+        open={shouldShowModal}
+      >
+        <ModalBody>
+          <HFlow alignItems="center">
+            <Icon
+              icon="exclamationTriangleFilled"
+              style={{ marginRight: '0.5rem' }}
+              size={3}
+              fill="danger"
+            />
+            <div>
+              <Heading level={1}>Delete instance {instanceId}?</Heading>
+              <Heading level={5}>
+                This will remove result information for this instance. You will
+                need to run the tests again to re-record data for this instance.
+              </Heading>
+              {deleteError && (
+                <Alert type="danger" style={{ margin: '1rem' }}>
+                  Delete error: {deleteError.toString()}
+                </Alert>
+              )}
+            </div>
+          </HFlow>
+        </ModalBody>
+        <ModalFooter>
+          <HFlow justifyContent="flex-end">
+            <Button
+              kind="normal"
+              skin="ghost"
+              onClick={() => setShowModal(false)}
+            >
+              <Text color="inherit">Cancel</Text>
+            </Button>
+            <Button
+              kind="danger"
+              skin="ghost"
+              onClick={deleteAction}
+              disabled={deleting}
+            >
+              <Icon icon="trashOutline" style={{ marginRight: '0.5rem' }} />
+              <Text color="inherit">{deleting ? 'Resetting' : 'Reset'}</Text>
+            </Button>
+          </HFlow>
+        </ModalFooter>
+      </Modal>
+      <Button
+        kind="normal"
+        size="small"
+        skin="ghost"
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowModal(true);
+        }}
+      >
+        <Icon icon="trashOutline" style={{ marginRight: '0.5rem' }} />
+        <Text color="inherit">Reset</Text>
+      </Button>
+    </>
+  );
+};

--- a/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
+++ b/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
@@ -82,7 +82,7 @@ export const ResetInstanceButton = ({
               <Heading level={1}>Delete instance {instanceId}?</Heading>
               <Heading level={5}>
                 This will remove result information for this instance. You will
-                need to run the tests again to re-record data for this instance.
+                need to run the tests with the case ci-build-id again to re-record data for this instance.
               </Heading>
               {deleteError && (
                 <Alert type="danger" style={{ margin: '1rem' }}>

--- a/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
+++ b/packages/dashboard/src/run/runDetails/resetInstance/resetInstanceButton.tsx
@@ -58,7 +58,6 @@ export const ResetInstanceButton = ({
     (e) => {
       e.stopPropagation();
       e.preventDefault();
-      console.log('deleting here');
       startDeleteInstance();
     },
     [startDeleteInstance]

--- a/packages/mongo/src/config.ts
+++ b/packages/mongo/src/config.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config';
+
 export const MONGODB_URI =
   process.env.MONGODB_URI || 'mongodb://localhost:27017';
 export const MONGODB_DATABASE = process.env.MONGODB_DATABASE || 'sorry-cypress';


### PR DESCRIPTION
Basically, my tests sometimes fail due to flakiness, and I need some way to reset only a specific instance, instead of having to run the whole suite again.

This allows sorry cypress to run just the failed tests again by making it as if they haven't been picked up by any executor yet.

Happy to hear any comments you have.