### PR TITLE
feat: allow linking directly to a project/build-id combination

### DIFF
--- a/packages/dashboard/src/root.tsx
+++ b/packages/dashboard/src/root.tsx
@@ -1,7 +1,8 @@
 import { ApolloProvider } from '@apollo/client';
+import { RunRedirect } from '@src/run/runsRedirect';
 import { ThemeProvider } from 'bold-ui';
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Content, Footer, Header, Layout } from './components';
 import { InstanceDetailsView } from './instance/instanceDetailsView';
 import { client } from './lib/apolloClient';
@@ -61,7 +62,13 @@ export const Root = () => {
               <Content>
                 <Route path="/" exact component={ProjectsView} />
 
-                <Route path="/:projectId+/runs" component={RunsView} />
+                <Switch>
+                  <Route
+                    path="/:projectId+/runs/:buildId"
+                    component={RunRedirect}
+                  />
+                  <Route path="/:projectId+/runs" component={RunsView} />
+                </Switch>
                 <Route path="/:projectId+/edit" component={ProjectEditView} />
                 <Route path="/run/:id" component={RunDetailsView} />
                 <Route

--- a/packages/dashboard/src/run/runsRedirect.tsx
+++ b/packages/dashboard/src/run/runsRedirect.tsx
@@ -1,0 +1,33 @@
+import { useGetRunsFeed } from '@src/run/runsFeed/useGetRunFeed';
+import React from 'react';
+import { Redirect } from 'react-router';
+
+type RunRedirectProps = {
+  match: {
+    params: {
+      projectId: string;
+      buildId: string;
+    };
+  };
+};
+
+export function RunRedirect({
+  match: {
+    params: { projectId, buildId },
+  },
+}: RunRedirectProps) {
+  const [runsFeed, loadMore, loading, error] = useGetRunsFeed({
+    projectId,
+    search: buildId,
+  });
+
+  return !loading && runsFeed && runsFeed.runs.length > 0 ? (
+    <Redirect to={`/run/${runsFeed.runs[0].runId}`} />
+  ) : loading ? (
+    <div>
+      Redirecting to run with build id {buildId} in {projectId}
+    </div>
+  ) : (
+    <div>Associated run not found</div>
+  );
+}


### PR DESCRIPTION
Small PR to do a thing that we're now constantly doing manually. I haven't found a way to link directly to a project/build-id combination, so I've added one.

I'm not really proud of the implementation, but I couldn't find a better way of implementing the redirect logic using react router.
