### PR TITLE
Delete runs in daterange in batches

### DIFF
--- a/packages/api/src/datasources/instances.ts
+++ b/packages/api/src/datasources/instances.ts
@@ -85,29 +85,4 @@ export class InstancesAPI extends DataSource {
       instanceId: result.result.ok === 1 ? instanceId : undefined,
     };
   }
-
-  async deleteInstancesInDateRange(startDate: Date, endDate: Date) {
-    if (startDate > endDate) {
-      return {
-        success: false,
-        message: `startDate: ${startDate.toISOString()} should be less than endDate: ${endDate.toISOString()}`,
-        runIds: [],
-      };
-    }
-    const response = await Collection.instance()
-      .aggregate([
-        {
-          $match: {
-            'run.createdAt': {
-              $lte: endDate.toISOString(),
-              $gte: startDate.toISOString(),
-            },
-          },
-        },
-      ])
-      .toArray();
-
-    const runIds = response.map((x) => x.runId) as string[];
-    return await this.deleteInstancesByRunIds(runIds);
-  }
 }

--- a/packages/api/src/datasources/runs.ts
+++ b/packages/api/src/datasources/runs.ts
@@ -124,15 +124,6 @@ export class RunsAPI extends DataSource {
     };
   }
 
-  async deleteRunsInDateRange(
-    startDate: Date,
-    endDate: Date,
-    limit: number = 0
-  ) {
-    const getResult = await this.getRunsInDateRange(startDate, endDate, limit);
-    return this.deleteRunsByIds(getResult.runIds);
-  }
-
   async getRunsInDateRange(startDate: Date, endDate: Date, limit: number = 0) {
     if (startDate > endDate) {
       return {
@@ -148,6 +139,7 @@ export class RunsAPI extends DataSource {
           $gte: startDate.toISOString(),
         },
       })
+      .project({ _id: 0, runId: 1 })
       .limit(limit)
       .toArray();
     const runIds = response.map((x) => x.runId);

--- a/packages/mongo/src/db.ts
+++ b/packages/mongo/src/db.ts
@@ -76,6 +76,7 @@ async function createIndexes() {
     Collection.run().createIndex({ 'meta.ciBuildId': 1 }),
 
     Collection.instance().createIndex({ instanceId: 1 }, { unique: true }),
+    Collection.instance().createIndex({ runId: 1 }),
     Collection.project().createIndex({ projectId: 1 }, { unique: true }),
     Collection.runTimeout().createIndex({ timeoutAfter: 1 }, { unique: false }),
   ]);


### PR DESCRIPTION
This PR changes the behavior of the deletion of runs in a specified date range.
Previously, it used a very slow `aggregate` to find the `instances` for the `runs` that should be deleted and tried to delete them all at once. This timeouted at various ends in larger setups.
With this change, it will now process the deletion in batches:
1. Get a batch of `runIds`
2. Delete all associated `instances` for those `runIds`
3. Delete the `runs` for those `runIds`
4. Repeat until no more `runs` are found for the defined date-range
5. 
To make it even faster, a new index for `runId` is added to the `instance` collection.