### PR TITLE
refactore testResults to use materialui

### DIFF
--- a/packages/dashboard/src/components/common/testResults.tsx
+++ b/packages/dashboard/src/components/common/testResults.tsx
@@ -1,93 +1,127 @@
-import { HFlow, Icon, Text, Tooltip } from 'bold-ui';
+import {
+  ErrorOutlineSharp,
+  RadioButtonUnchecked,
+  RedoRounded,
+  Sync,
+} from '@mui/icons-material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { Chip, Tooltip } from '@mui/material';
+import { WithMaterial } from '@sorry-cypress/dashboard/lib/material';
 import React from 'react';
 
+enum CHIP_COLOR {
+  DEFAULT = '#929292',
+  OVERALL = '#98c2f0',
+  RETRIES = '#e3e386',
+  SUCCESS = '#85caa8',
+  FAILURE = '#ebb8b8',
+  SKIPPED = '#f5d79e',
+}
+
+const addOpacityToHexColor = (color: CHIP_COLOR, opacity: 0 | 25 | 50 | 75) => {
+  switch (opacity) {
+    case 0:
+      return color + '00';
+    case 25:
+      return color + '40';
+    case 50:
+      return color + '7F';
+    case 75:
+      return color + 'BF';
+  }
+};
+
 export const TestSuccessBadge = ({ value }: { value: number }) => {
-  const color = value ? 'success' : 'disabled';
+  const color = value ? CHIP_COLOR.SUCCESS : CHIP_COLOR.DEFAULT;
   return (
-    <Text color={color}>
-      <Tooltip text="Passed Tests">
-        <HFlow alignItems="center" hSpacing={0.5}>
-          <Icon icon="checkCircleOutline" size={1} />
-          {value}
-        </HFlow>
+    <WithMaterial>
+      <Tooltip title="Passed Tests">
+        <Chip
+          icon={<CheckCircleOutlineIcon style={{ fill: color }} />}
+          label={value}
+          style={{ backgroundColor: addOpacityToHexColor(color, 25) }}
+        />
       </Tooltip>
-    </Text>
+    </WithMaterial>
   );
 };
 
 export const TestFailureBadge = ({ value }: { value: number }) => {
-  const color = value ? 'danger' : 'disabled';
+  const color = value ? CHIP_COLOR.FAILURE : CHIP_COLOR.DEFAULT;
   return (
-    <Text color={color}>
-      <Tooltip text="Failed Tests">
-        <HFlow alignItems="center" hSpacing={0.5}>
-          <Icon icon="exclamationTriangleOutline" size={1} />
-          {value}
-        </HFlow>
+    <WithMaterial>
+      <Tooltip title="Failed Tests">
+        <Chip
+          icon={<ErrorOutlineSharp style={{ fill: color }} />}
+          label={value}
+          style={{ backgroundColor: addOpacityToHexColor(color, 25) }}
+        />
       </Tooltip>
-    </Text>
+    </WithMaterial>
   );
 };
 
-export const TestRetriesSkippedBadge = ({
-  retries,
-  skipped,
-}: {
-  retries: number;
-  skipped: number;
-}) => {
+export const TestSkippedBadge = ({ value }: { value: number; style?: any }) => {
+  const color = value ? CHIP_COLOR.SKIPPED : CHIP_COLOR.DEFAULT;
   return (
-    <div style={{ display: 'flex' }}>
-      <TestRetriesBadge value={retries} />
-      <TestSkippedBadge value={skipped} style={{ paddingLeft: '1rem' }} />
-    </div>
-  );
-};
-
-export const TestSkippedBadge = ({
-  value,
-  style,
-}: {
-  value: number;
-  style?: any;
-}) => {
-  const color = value ? 'normal' : 'disabled';
-  return (
-    <Text color={color} style={style}>
-      <Tooltip text="Skipped Tests">
-        <HFlow alignItems="center" hSpacing={0.5}>
-          <Icon icon="timesOutline" size={1} />
-          {value}
-        </HFlow>
+    <WithMaterial>
+      <Tooltip title="Skipped Tests">
+        <Chip
+          icon={
+            <RedoRounded
+              fontSize={'small'}
+              style={{
+                fill: color,
+                border: `solid 2px ${color}`,
+                borderRadius: '50%',
+              }}
+            />
+          }
+          label={value}
+          style={{ backgroundColor: addOpacityToHexColor(color, 25) }}
+        />
       </Tooltip>
-    </Text>
+    </WithMaterial>
   );
 };
 
 export const TestRetriesBadge = ({ value }: { value: number }) => {
-  const color = value ? 'alert' : 'disabled';
+  const color = value ? CHIP_COLOR.RETRIES : CHIP_COLOR.DEFAULT;
 
   return (
-    <Text color={color}>
-      <Tooltip text="Retried Tests">
-        <HFlow alignItems="center" hSpacing={0.5}>
-          <Icon icon="sync" size={1} />
-          {value}
-        </HFlow>
+    <WithMaterial>
+      <Tooltip title="Retried Tests">
+        <Chip
+          icon={
+            <Sync
+              fontSize={'small'}
+              style={{
+                fill: color,
+                border: `solid 2px ${color}`,
+                borderRadius: '50%',
+              }}
+            />
+          }
+          label={value}
+          style={{ backgroundColor: addOpacityToHexColor(color, 25) }}
+        />
       </Tooltip>
-    </Text>
+    </WithMaterial>
   );
 };
 
 export const TestOverallBadge = ({ value }: { value: number }) => {
   return (
-    <Text>
-      <Tooltip text="Total Tests">
-        <HFlow alignItems="center" hSpacing={0.5}>
-          <Icon icon="fileWithItensOutline" size={1} />
-          {value}
-        </HFlow>
+    <WithMaterial>
+      <Tooltip title="Total Tests">
+        <Chip
+          icon={<RadioButtonUnchecked style={{ fill: CHIP_COLOR.OVERALL }} />}
+          label={value}
+          style={{
+            backgroundColor: addOpacityToHexColor(CHIP_COLOR.OVERALL, 25),
+          }}
+        />
       </Tooltip>
-    </Text>
+    </WithMaterial>
   );
 };


### PR DESCRIPTION
For new features:

- [x] **issue:**
[🙏🏻 Help Needed: boldui -> Material-UI #401](https://github.com/sorry-cypress/sorry-cypress/issues/401)

- [x]  **Describe the use-case in details:** 
refactored TestResults.tsx to use MatrialUI.
The drafts from the issue (made by https://github.com/ImanMahmoudinasab have served as design template)

- [x] **Ensure the solution is backwards-compatible**:
Dependence on Material-UI



- [x] ** Test it. Submit screenshots / outputs / tests together with the PR**:
![Bildschirmfoto_2021-10-04_um_13 00 49](https://user-images.githubusercontent.com/18060129/135842721-905f2679-e3ff-48a2-a387-ca107e245e87.png)
![Bildschirmfoto_2021-10-04_um_13 01 03](https://user-images.githubusercontent.com/18060129/135842725-8a461fba-d6c8-4c58-85dc-6df3f0e36358.png)
![Bildschirmfoto_2021-10-04_um_13 01 13](https://user-images.githubusercontent.com/18060129/135842729-d738133e-3b62-4c77-82d3-0a69e74833aa.png)


