### PR TITLE
fix: data grid pagination when more than 100 specs

### DIFF
--- a/packages/dashboard/src/run/runDetails/details.tsx
+++ b/packages/dashboard/src/run/runDetails/details.tsx
@@ -54,7 +54,7 @@ export const RunDetails: RunDetailsComponent = (props) => {
       <DataGrid
         style={{ border: 0 }}
         autoHeight
-        hideFooter
+        hideFooter={rows.length <= 100}
         getRowId={(row) => row.instanceId}
         rows={rows}
         loading={false}


### PR DESCRIPTION
For bug fixes:

- [x] #470 

Closes #470 