### PR TITLE
Fix show running specs when filtered by failed tests

### DIFF
--- a/packages/dashboard/src/run/runDetails/details.tsx
+++ b/packages/dashboard/src/run/runDetails/details.tsx
@@ -46,7 +46,7 @@ export const RunDetails: RunDetailsComponent = (props) => {
         stats: spec.results?.stats,
         retries: spec.results?.retries ?? 0,
       });
-      return ['failed', 'pending'].includes(state);
+      return ['failed', 'pending', 'running'].includes(state);
     });
 
   return (


### PR DESCRIPTION
- [x] related issue #447 

When user clicks on only show failed specs, it is better to show pending and running specs as well to user know what specs have not run yet and which are running. This is a common use case of the filtering feature. In the future, we will let users decide which spec status want to see by choosing the status one by one. 

Closes #447 