### PR TITLE
updated the CloudFormation Stack with proper health checks

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -208,8 +208,8 @@ Resources:
   TargetGroupDirector:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /
+      HealthCheckIntervalSeconds: 15
+      HealthCheckPath: /ping
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -217,7 +217,7 @@ Resources:
       Name: !Join ['-', [!Ref 'AWS::StackName', 'director-tg']]
       Port: 1234
       Matcher:
-        HttpCode: 302
+        HttpCode: 200
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId: !Ref VPC
@@ -226,8 +226,8 @@ Resources:
   TargetGroupAPI:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /
+      HealthCheckIntervalSeconds: 15
+      HealthCheckPath: /.well-known/apollo/server-health
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -235,7 +235,7 @@ Resources:
       Name: !Join ['-', [!Ref 'AWS::StackName', 'api-tg']]
       Port: 4000
       Matcher:
-        HttpCode: 400
+        HttpCode: 200
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId: !Ref VPC
@@ -244,7 +244,7 @@ Resources:
   TargetGroupDashboard:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckIntervalSeconds: 6
+      HealthCheckIntervalSeconds: 15
       HealthCheckPath: /
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5


### PR DESCRIPTION
Hi there, I updated the health checks in the CloudFormation stack as they were a bit cumbersome. 

- The Apollo webserver for GraphQL offers `/.well-known/apollo/server-health` as [health path](https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/) -> you get HTTP 200 as return value which is way more intuitive matcher than 400 :) 
- I also updated the Director health check to `/ping` which allows the usage of HTTP 200 as matcher

I increased `HealthCheckIntervalSeconds` to 15 seconds. This is more than enough and you have less log entries with simple health check GET requests in AWS Cloudwatch. I deployed the improved health checks on my cluster today and they work fine.

