### PR TITLE
Remove docker.io domain from Image pull in CloudFormation .yml

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -395,7 +395,7 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ContainerDefinitions:
-        - Image: docker.io/mongo:4
+        - Image: mongo:4
           Essential: true
           LogConfiguration:
             LogDriver: awslogs
@@ -410,7 +410,7 @@ Resources:
               Value: sorry-cypress
           Name: mongo
 
-        - Image: docker.io/agoldis/sorry-cypress-director
+        - Image: agoldis/sorry-cypress-director
           Essential: true
           PortMappings:
             - ContainerPort: 1234
@@ -440,7 +440,7 @@ Resources:
               Condition: START
           Name: director
 
-        - Image: docker.io/agoldis/sorry-cypress-api
+        - Image: agoldis/sorry-cypress-api
           PortMappings:
             - ContainerPort: 4000
           LogConfiguration:
@@ -459,7 +459,7 @@ Resources:
               Condition: START
           Name: api
 
-        - Image: docker.io/agoldis/sorry-cypress-dashboard
+        - Image: agoldis/sorry-cypress-dashboard
           PortMappings:
             - ContainerPort: 8080
           LogConfiguration:


### PR DESCRIPTION
Due to URL changes within Docker, docker.io needs to be removed for successful pulling Docker Images of Sorry-Cypress.

Use Case: AWS CloudFormation throws an error when pulling images from Docker as docker.io is not supported anymore.