### PR TITLE
fix: encode project ids wherever it is used in url

### DIFF
--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -162,7 +162,7 @@ export const ProjectListMenu: ProjectListMenuType = ({
               key={decodeURIComponent(project.projectId)}
               sx={{ pl: 4 }}
               component={RouterLink}
-              to={`/${project.projectId}/runs`}
+              to={`/${encodeURIComponent(project.projectId)}/runs`}
               onClick={onItemClick}
             >
               <ListItemIcon
@@ -194,7 +194,7 @@ export const ProjectListMenu: ProjectListMenuType = ({
                 aria-label={decodeURIComponent(project.projectId)}
                 sx={{ opacity: 0.6, padding: 1.5, color: project.projectColor }}
                 component={RouterLink}
-                to={`/${project.projectId}/runs`}
+                to={`/${encodeURIComponent(project.projectId)}/runs`}
                 onClick={onItemClick}
                 size="large"
               >
@@ -218,13 +218,13 @@ export const ProjectDetailsMenu: ProjectDetailsMenuType = ({
   const projectMenuItems = [
     {
       label: 'Latest runs',
-      link: `/${projectId}/runs`,
+      link: `/${encodeURIComponent(projectId)}/runs`,
       iconComponent: PlayLessonIcon,
       type: NavItemType.latestRuns,
     },
     {
       label: 'Project settings',
-      link: `/${projectId}/edit`,
+      link: `/${encodeURIComponent(projectId)}/edit`,
       iconComponent: SettingsIcon,
       type: NavItemType.projectSettings,
     },

--- a/packages/dashboard/src/lib/navigation.ts
+++ b/packages/dashboard/src/lib/navigation.ts
@@ -33,7 +33,7 @@ const detectBadPath = (fn: (value: string) => string) => (value: unknown) => {
 };
 
 export const getProjectPath = detectBadPath(
-  (projectId: string) => `${projectId}/runs`
+  (projectId: string) => `${encodeURIComponent(projectId)}/runs`
 );
 export const getRunPath = detectBadPath((id: string) => `run/${id}`);
 export const getInstancePath = detectBadPath((id: string) => `instance/${id}`);

--- a/packages/dashboard/src/project/projectEditView.tsx
+++ b/packages/dashboard/src/project/projectEditView.tsx
@@ -42,7 +42,7 @@ export function ProjectEditView() {
   }, [isNewProject]);
 
   function onProjectCreated({ projectId }: { projectId: string }) {
-    navigate(`/${projectId}/edit`);
+    navigate(`/${encodeURIComponent(projectId)}/edit`);
   }
 
   return (

--- a/packages/dashboard/src/project/projectListItem.tsx
+++ b/packages/dashboard/src/project/projectListItem.tsx
@@ -24,7 +24,7 @@ export function ProjectListItem({ project }: ProjectListItemProps) {
   return (
     <Link
       component={RouterLink}
-      to={`/${project.projectId}/runs`}
+      to={`/${encodeURIComponent(project.projectId)}/runs`}
       underline="none"
     >
       <Card


### PR DESCRIPTION
For bug fixes:

- [x] Add a reference to the original issue #509  @fsmaia
- [x] Add a test and / or some kind of instructions to verify the fix
![image](https://user-images.githubusercontent.com/5295554/146127769-b4b1281d-1e2b-402d-88c6-f98062381dba.png)

![image](https://user-images.githubusercontent.com/5295554/146127918-beba3d15-1342-46a5-b129-bef545e0352e.png)

