### PR TITLE
Add HOST parameter to API config.

### DIFF
--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
 
+export const HOST = process.env.HOST || 'localhost';
 export const PORT = process.env.PORT || 4000;
 export const PAGE_ITEMS_LIMIT = Number(process.env.PAGE_ITEMS_LIMIT ?? 20);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,7 +3,7 @@ import 'source-map-support/register'
 
 import { initMongoNoIndexes } from '@sorry-cypress/mongo';
 import { ApolloServer } from 'apollo-server';
-import { PORT } from './config';
+import { HOST, PORT } from './config';
 import { InstancesAPI } from './datasources/instances';
 import { ProjectsAPI } from './datasources/projects';
 import { RunsAPI } from './datasources/runs';
@@ -32,7 +32,7 @@ async function start() {
   });
 
   server
-    .listen({ port: PORT })
+    .listen({ host: HOST, port: PORT })
     .then(({ url }) => {
       console.log(`🚀 Apollo server is ready at ${url}`);
     })


### PR DESCRIPTION
Hi everyone, I'm not a frequent contributor to OSS so please pardon the formatting.

This is a *very* basic add-on that probably should have already existed in the project. I couldn't find any open issues relating to it, but the use-case is very simple. There are folks such as myself that don't have the luxury of spinning up the CloudFormation template or standing up a bunch of dedicated infrastructure to run this application in its default configuration. This requires us to tweak the configuration to support our use-case. Unfortunately, sorry-cypress (the API package specifically) does not support specifying an alternative `HOST` i.e. `0.0.0.0`, which breaks things like docker configurations that rely on `bridge` networking modes. For our specific use-case, we didn't want to have to use `awsvpc` networking mode in ECS to get this application working with the default hard-coded `localhost` host address.

Please let me know if this change requires any additional detail or if it requires adding a test to merge, and I'll do my best to address those items. This should not require any special maintenance, as it merely uses an optional config parameter in the underlying `apollo-server` (and `express` framework underneath that). I tested the default setting specified (`localhost`) as well as a change (`0.0.0.0`) in docker via docker-compose on my local machine, and it is tested working.

--- Original Template Spec ---

For new features:

- [ ] It's better to first discuss features proposal in [Discussions](https://github.com/sorry-cypress/sorry-cypress/discussions) or [Slack](https://sorry-cypress.slack.com/join/shared_invite/zt-eis1h6jl-tJELaD7q9UGEhMP8WHJOaw#/)
- [✅] Describe the use-case in details
- [✅] Ensure the solution is backwards-compatible
- [ ] Test it. Submit screenshots / outputs / tests together with the PR.
