### PR TITLE
use commit message instead of sha

### DIFF
--- a/packages/director/src/execution/in-memory.ts
+++ b/packages/director/src/execution/in-memory.ts
@@ -53,7 +53,7 @@ const createRun: ExecutionDriver['createRun'] = async (
 
   const runId = generateRunIdHash(
     ciBuildId,
-    params.commit.sha,
+    params.commit.message ?? params.commit.sha,
     params.projectId
   );
 

--- a/packages/director/src/execution/in-memory.ts
+++ b/packages/director/src/execution/in-memory.ts
@@ -51,11 +51,7 @@ const createRun: ExecutionDriver['createRun'] = async (
 ): Promise<CreateRunResponse> => {
   const ciBuildId = getRunCiBuildId(params);
 
-  const runId = generateRunIdHash(
-    ciBuildId,
-    params.commit.message ?? params.commit.sha,
-    params.projectId
-  );
+  const runId = generateRunIdHash(ciBuildId, params.projectId);
 
   const machineId = generateUUID();
 

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -50,7 +50,7 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
 
   const runId = generateRunIdHash(
     ciBuildId,
-    params.commit.sha,
+    params.commit.message ?? params.commit.sha,
     params.projectId
   );
 

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -48,11 +48,7 @@ export const getById = getRunById;
 export const createRun: ExecutionDriver['createRun'] = async (params) => {
   const ciBuildId = getRunCiBuildId(params);
 
-  const runId = generateRunIdHash(
-    ciBuildId,
-    params.commit.message ?? params.commit.sha,
-    params.projectId
-  );
+  const runId = generateRunIdHash(ciBuildId, params.projectId);
 
   const groupId = params.group ?? generateGroupId(params.platform, ciBuildId);
 

--- a/packages/director/src/lib/hash.ts
+++ b/packages/director/src/lib/hash.ts
@@ -4,10 +4,10 @@ import uuid from 'uuid/v4';
 
 export const generateRunIdHash = (
   ciBuildId: string,
-  sha: string,
+  message: string,
   projectId: string
 ) => {
-  return md5(ciBuildId + sha + projectId);
+  return md5(ciBuildId + message + projectId);
 };
 
 // not sure how specific that should be

--- a/packages/director/src/lib/hash.ts
+++ b/packages/director/src/lib/hash.ts
@@ -2,12 +2,8 @@ import { PlatformData } from '@sorry-cypress/common';
 import md5 from 'md5';
 import uuid from 'uuid/v4';
 
-export const generateRunIdHash = (
-  ciBuildId: string,
-  message: string,
-  projectId: string
-) => {
-  return md5(ciBuildId + message + projectId);
+export const generateRunIdHash = (ciBuildId: string, projectId: string) => {
+  return md5(ciBuildId + projectId);
 };
 
 // not sure how specific that should be


### PR DESCRIPTION
For bug fixes:

- [x] Add a reference to the original issue: #541 

Closes #541 

usually in PRs, we merge the branch with the master so we can have different `commit sha` in parallel runs. but the commit message is the same. so instead of `commit sha` is better to use `commit message` for runId.

_we are using bitbucket CI and in bitbucket CI we have this situation_