### PR TITLE
Add support for overriding s3 endpoint

### DIFF
--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -1,6 +1,7 @@
 export const S3_BUCKET = process.env.S3_BUCKET || 'sorry-cypress';
 export const S3_REGION = process.env.S3_REGION || 'us-east-1';
 export const S3_ACL = process.env.S3_ACL || 'public-read';
+export const S3_ENDPOINT_URL = process.env.S3_ENDPOINT_URL || undefined;
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || undefined;
 export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || undefined;
 export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || undefined;

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -4,6 +4,7 @@ import { sanitizeS3KeyPrefix } from '../utils/';
 import {
   S3_ACL,
   S3_BUCKET,
+  S3_ENDPOINT_URL,
   S3_IMAGE_KEY_PREFIX,
   S3_READ_URL_PREFIX,
   S3_REGION,
@@ -15,10 +16,16 @@ const BUCKET_URL = `https://${S3_BUCKET}.s3.amazonaws.com`;
 const ImageContentType = 'image/png';
 const VideoContentType = 'video/mp4';
 
-const s3 = new aws.S3({
+const s3Config: aws.S3.Types.ClientConfiguration = {
   region: S3_REGION,
   signatureVersion: 'v4',
-});
+};
+
+if (S3_ENDPOINT_URL) {
+  s3Config.endpoint = new aws.Endpoint(S3_ENDPOINT_URL);
+}
+
+const s3 = new aws.S3(s3Config);
 
 interface GetUploadURLParams {
   key: string;


### PR DESCRIPTION
Closes  #482

- [x] Describe the use-case in details: 
    This allows using any S3 compatible APIs as a storage backend (like Digital Ocean Spaces or GCP Storage). There was already support to override read url for S3, this makes it possible to override upload url too.
- [x] Ensure the solution is backwards-compatible:
     We update the s3 config only if the new env var is present
- [ ] Test it. Submit screenshots / outputs / tests together with the PR.

