### PR TITLE
Updating GH actions to latest versions

### DIFF
--- a/.github/workflows/dockerimage-api.yml
+++ b/.github/workflows/dockerimage-api.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Docker Login
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v1.14.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/dockerimage-dashboard.yml
+++ b/.github/workflows/dockerimage-dashboard.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Docker Login
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v1.14.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/dockerimage-director.yml
+++ b/.github/workflows/dockerimage-director.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Docker Login
-        uses: docker/login-action@v1.6.0
+        uses: docker/login-action@v1.14.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
This is just to update the GH Actions rules with their updates, specially `login-action` with several updates including aws-sdk updates and e2e coverage
