### PR TITLE
fix: fixes #555 mocha statuses are converted to cypress statuses

### DIFF
--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -1,10 +1,16 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
 export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X];
+} &
+  { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -12,206 +18,13 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  BitbucketHookType: any;
-  DateTime: any;
   GenericHookType: any;
-  GithubHookType: any;
   SlackHookType: any;
   SlackResultFilter: any;
+  GithubHookType: any;
+  BitbucketHookType: any;
   TeamsHookType: any;
-};
-
-export type BitbucketHook = {
-  __typename?: 'BitbucketHook';
-  bitbucketBuildName?: Maybe<Scalars['String']>;
-  bitbucketToken?: Maybe<Scalars['String']>;
-  bitbucketUsername?: Maybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['BitbucketHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type Commit = {
-  __typename?: 'Commit';
-  authorEmail?: Maybe<Scalars['String']>;
-  authorName?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  remoteOrigin?: Maybe<Scalars['String']>;
-  sha?: Maybe<Scalars['String']>;
-};
-
-export type CreateBitbucketHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateGenericHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateGithubHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateProjectInput = {
-  inactivityTimeoutSeconds: Scalars['Int'];
-  projectColor?: InputMaybe<Scalars['String']>;
-  projectId: Scalars['ID'];
-};
-
-export type CreateSlackHookInput = {
-  projectId: Scalars['ID'];
-  slackResultFilter?: InputMaybe<Scalars['SlackResultFilter']>;
-};
-
-export type CreateTeamsHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CypressConfig = {
-  __typename?: 'CypressConfig';
-  video: Scalars['Boolean'];
-  videoUploadOnPasses: Scalars['Boolean'];
-};
-
-export type DeleteHookInput = {
-  hookId: Scalars['ID'];
-  projectId: Scalars['String'];
-};
-
-export type DeleteHookResponse = {
-  __typename?: 'DeleteHookResponse';
-  hookId: Scalars['ID'];
-  projectId: Scalars['String'];
-};
-
-export type DeleteProjectResponse = {
-  __typename?: 'DeleteProjectResponse';
-  message: Scalars['String'];
-  projectIds: Array<Maybe<Scalars['ID']>>;
-  success: Scalars['Boolean'];
-};
-
-export type DeleteRunResponse = {
-  __typename?: 'DeleteRunResponse';
-  message: Scalars['String'];
-  runIds: Array<Maybe<Scalars['ID']>>;
-  success: Scalars['Boolean'];
-};
-
-export type Filters = {
-  key?: InputMaybe<Scalars['String']>;
-  like?: InputMaybe<Scalars['String']>;
-  value?: InputMaybe<Scalars['String']>;
-};
-
-export type GenericHook = {
-  __typename?: 'GenericHook';
-  headers?: Maybe<Scalars['String']>;
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['GenericHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type GithubHook = {
-  __typename?: 'GithubHook';
-  githubContext?: Maybe<Scalars['String']>;
-  githubToken?: Maybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['GithubHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type Hook = {
-  __typename?: 'Hook';
-  bitbucketBuildName?: Maybe<Scalars['String']>;
-  bitbucketToken?: Maybe<Scalars['String']>;
-  bitbucketUsername?: Maybe<Scalars['String']>;
-  githubContext?: Maybe<Scalars['String']>;
-  githubToken?: Maybe<Scalars['String']>;
-  headers?: Maybe<Scalars['String']>;
-  hookEvents?: Maybe<Array<Maybe<Scalars['String']>>>;
-  hookId?: Maybe<Scalars['String']>;
-  hookType?: Maybe<Scalars['String']>;
-  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
-  slackResultFilter?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-};
-
-export type HookInput = {
-  bitbucketBuildName?: InputMaybe<Scalars['String']>;
-  bitbucketToken?: InputMaybe<Scalars['String']>;
-  bitbucketUsername?: InputMaybe<Scalars['String']>;
-  githubContext?: InputMaybe<Scalars['String']>;
-  githubToken?: InputMaybe<Scalars['String']>;
-  headers?: InputMaybe<Scalars['String']>;
-  hookEvents?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  hookId?: InputMaybe<Scalars['String']>;
-  hookType?: InputMaybe<Scalars['String']>;
-  slackBranchFilter?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  slackResultFilter?: InputMaybe<Scalars['String']>;
-  url: Scalars['String'];
-};
-
-export type Instance = {
-  __typename?: 'Instance';
-  groupId: Scalars['String'];
-  instanceId: Scalars['ID'];
-  projectId: Scalars['String'];
-  results?: Maybe<InstanceResults>;
-  run: Run;
-  runId: Scalars['ID'];
-  spec: Scalars['String'];
-};
-
-export type InstanceResults = {
-  __typename?: 'InstanceResults';
-  cypressConfig?: Maybe<CypressConfig>;
-  error?: Maybe<Scalars['String']>;
-  reporterStats?: Maybe<ReporterStats>;
-  screenshots: Array<InstanceScreeshot>;
-  stats: InstanceStats;
-  stdout?: Maybe<Scalars['String']>;
-  tests?: Maybe<Array<InstanceTest>>;
-  videoUrl?: Maybe<Scalars['String']>;
-};
-
-export type InstanceScreeshot = {
-  __typename?: 'InstanceScreeshot';
-  height: Scalars['Int'];
-  name?: Maybe<Scalars['String']>;
-  screenshotId: Scalars['String'];
-  screenshotURL?: Maybe<Scalars['String']>;
-  takenAt: Scalars['String'];
-  testId: Scalars['String'];
-  width: Scalars['Int'];
-};
-
-export type InstanceStats = {
-  __typename?: 'InstanceStats';
-  failures: Scalars['Int'];
-  passes: Scalars['Int'];
-  pending: Scalars['Int'];
-  skipped: Scalars['Int'];
-  suites: Scalars['Int'];
-  tests: Scalars['Int'];
-  wallClockDuration: Scalars['Int'];
-  wallClockEndedAt: Scalars['String'];
-  wallClockStartedAt: Scalars['String'];
-};
-
-export type InstanceTest = {
-  __typename?: 'InstanceTest';
-  attempts: Array<TestAttempt>;
-  body?: Maybe<Scalars['String']>;
-  displayError?: Maybe<Scalars['String']>;
-  state: TestState;
-  testId: Scalars['String'];
-  title: Array<Scalars['String']>;
+  DateTime: any;
 };
 
 export type Mutation = {
@@ -236,195 +49,334 @@ export type Mutation = {
   updateTeamsHook: TeamsHook;
 };
 
-
 export type MutationCreateBitbucketHookArgs = {
   input: CreateBitbucketHookInput;
 };
-
 
 export type MutationCreateGenericHookArgs = {
   input: CreateGenericHookInput;
 };
 
-
 export type MutationCreateGithubHookArgs = {
   input: CreateGithubHookInput;
 };
-
 
 export type MutationCreateProjectArgs = {
   project: CreateProjectInput;
 };
 
-
 export type MutationCreateSlackHookArgs = {
   input: CreateSlackHookInput;
 };
-
 
 export type MutationCreateTeamsHookArgs = {
   input: CreateTeamsHookInput;
 };
 
-
 export type MutationDeleteHookArgs = {
   input: DeleteHookInput;
 };
-
 
 export type MutationDeleteProjectArgs = {
   projectId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
-  runIds: Array<InputMaybe<Scalars['ID']>>;
+  runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
-  endDate: Scalars['DateTime'];
   startDate: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
 };
-
 
 export type MutationResetInstanceArgs = {
   instanceId: Scalars['ID'];
 };
 
-
 export type MutationUpdateBitbucketHookArgs = {
   input: UpdateBitbucketHookInput;
 };
-
 
 export type MutationUpdateGenericHookArgs = {
   input: UpdateGenericHookInput;
 };
 
-
 export type MutationUpdateGithubHookArgs = {
   input: UpdateGithubHookInput;
 };
-
 
 export type MutationUpdateProjectArgs = {
   input: UpdateProjectInput;
 };
 
-
 export type MutationUpdateSlackHookArgs = {
   input: UpdateSlackHookInput;
 };
-
 
 export type MutationUpdateTeamsHookArgs = {
   input: UpdateTeamsHookInput;
 };
 
-export enum OrderingOptions {
-  Asc = 'ASC',
-  Desc = 'DESC'
-}
+export type DeleteHookInput = {
+  projectId: Scalars['String'];
+  hookId: Scalars['ID'];
+};
 
-export type Project = {
-  __typename?: 'Project';
-  hooks: Array<Hook>;
-  inactivityTimeoutSeconds?: Maybe<Scalars['Int']>;
-  projectColor?: Maybe<Scalars['String']>;
+export type DeleteHookResponse = {
+  __typename?: 'DeleteHookResponse';
+  projectId: Scalars['String'];
+  hookId: Scalars['ID'];
+};
+
+export type SlackHook = {
+  __typename?: 'SlackHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['SlackHookType'];
+  hookEvents: Array<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['SlackResultFilter']>;
+  slackBranchFilter?: Maybe<Array<Scalars['String']>>;
+};
+
+export type CreateSlackHookInput = {
+  projectId: Scalars['ID'];
+  slackResultFilter?: Maybe<Scalars['SlackResultFilter']>;
+};
+
+export type UpdateSlackHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookEvents: Array<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['SlackResultFilter']>;
+  slackBranchFilter?: Maybe<Array<Scalars['String']>>;
+};
+
+export type GithubHook = {
+  __typename?: 'GithubHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['GithubHookType'];
+  githubToken?: Maybe<Scalars['String']>;
+  githubContext?: Maybe<Scalars['String']>;
+};
+
+export type CreateGithubHookInput = {
   projectId: Scalars['ID'];
 };
 
-export type ProjectInput = {
-  hooks?: InputMaybe<Array<InputMaybe<HookInput>>>;
-  inactivityTimeoutSeconds?: InputMaybe<Scalars['Int']>;
-  projectColor?: InputMaybe<Scalars['String']>;
-  projectId: Scalars['String'];
+export type UpdateGithubHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  githubToken?: Maybe<Scalars['String']>;
+  githubContext?: Maybe<Scalars['String']>;
+};
+
+export type BitbucketHook = {
+  __typename?: 'BitbucketHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['BitbucketHookType'];
+  bitbucketUsername?: Maybe<Scalars['String']>;
+  bitbucketToken?: Maybe<Scalars['String']>;
+  bitbucketBuildName?: Maybe<Scalars['String']>;
+};
+
+export type CreateBitbucketHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateBitbucketHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url?: Maybe<Scalars['String']>;
+  bitbucketUsername: Scalars['String'];
+  bitbucketToken?: Maybe<Scalars['String']>;
+  bitbucketBuildName?: Maybe<Scalars['String']>;
+};
+
+export type TeamsHook = {
+  __typename?: 'TeamsHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['TeamsHookType'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type CreateTeamsHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateTeamsHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type GenericHook = {
+  __typename?: 'GenericHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  headers?: Maybe<Scalars['String']>;
+  hookType: Scalars['GenericHookType'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type CreateGenericHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateGenericHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  headers?: Maybe<Scalars['String']>;
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type Hook = {
+  __typename?: 'Hook';
+  hookId?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+  headers?: Maybe<Scalars['String']>;
+  hookEvents?: Maybe<Array<Maybe<Scalars['String']>>>;
+  hookType?: Maybe<Scalars['String']>;
+  githubToken?: Maybe<Scalars['String']>;
+  githubContext?: Maybe<Scalars['String']>;
+  bitbucketUsername?: Maybe<Scalars['String']>;
+  bitbucketToken?: Maybe<Scalars['String']>;
+  bitbucketBuildName?: Maybe<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['String']>;
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type HookInput = {
+  hookId?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+  headers?: Maybe<Scalars['String']>;
+  hookEvents?: Maybe<Array<Maybe<Scalars['String']>>>;
+  hookType?: Maybe<Scalars['String']>;
+  githubToken?: Maybe<Scalars['String']>;
+  githubContext?: Maybe<Scalars['String']>;
+  bitbucketUsername?: Maybe<Scalars['String']>;
+  bitbucketToken?: Maybe<Scalars['String']>;
+  bitbucketBuildName?: Maybe<Scalars['String']>;
+  slackResultFilter?: Maybe<Scalars['String']>;
+  slackBranchFilter?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type Query = {
   __typename?: 'Query';
-  instance?: Maybe<Instance>;
-  project?: Maybe<Project>;
   projects: Array<Project>;
-  run?: Maybe<Run>;
-  runFeed: RunFeed;
+  project?: Maybe<Project>;
   runs: Array<Maybe<Run>>;
+  runFeed: RunFeed;
+  run?: Maybe<Run>;
+  instance?: Maybe<Instance>;
   specStats?: Maybe<SpecStats>;
 };
 
-
-export type QueryInstanceArgs = {
-  id: Scalars['ID'];
+export type QueryProjectsArgs = {
+  orderDirection?: Maybe<OrderingOptions>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
-
 
 export type QueryProjectArgs = {
   id: Scalars['ID'];
 };
 
-
-export type QueryProjectsArgs = {
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
-  orderDirection?: InputMaybe<OrderingOptions>;
+export type QueryRunsArgs = {
+  orderDirection?: Maybe<OrderingOptions>;
+  cursor?: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+export type QueryRunFeedArgs = {
+  cursor?: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
+};
 
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
 
-
-export type QueryRunFeedArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
+export type QueryInstanceArgs = {
+  id: Scalars['ID'];
 };
-
-
-export type QueryRunsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
-  orderDirection?: InputMaybe<OrderingOptions>;
-};
-
 
 export type QuerySpecStatsArgs = {
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
   spec: Scalars['String'];
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-export type ReporterStats = {
-  __typename?: 'ReporterStats';
-  duration?: Maybe<Scalars['Int']>;
-  end?: Maybe<Scalars['String']>;
-  failures?: Maybe<Scalars['Int']>;
-  passes?: Maybe<Scalars['Int']>;
-  pending?: Maybe<Scalars['Int']>;
-  start?: Maybe<Scalars['String']>;
-  suites?: Maybe<Scalars['Int']>;
-  tests?: Maybe<Scalars['Int']>;
-};
-
-export type ResetInstanceResponse = {
-  __typename?: 'ResetInstanceResponse';
-  instanceId: Scalars['ID'];
+export type DeleteRunResponse = {
+  __typename?: 'DeleteRunResponse';
+  success: Scalars['Boolean'];
   message: Scalars['String'];
-  success?: Maybe<Scalars['Boolean']>;
+  runIds: Array<Maybe<Scalars['ID']>>;
+};
+
+export type SpecStats = {
+  __typename?: 'SpecStats';
+  spec: Scalars['String'];
+  avgWallClockDuration: Scalars['Int'];
+  count: Scalars['Int'];
+};
+
+export type Project = {
+  __typename?: 'Project';
+  projectId: Scalars['ID'];
+  hooks: Array<Hook>;
+  inactivityTimeoutSeconds?: Maybe<Scalars['Int']>;
+  projectColor?: Maybe<Scalars['String']>;
+};
+
+export type CreateProjectInput = {
+  projectId: Scalars['ID'];
+  inactivityTimeoutSeconds: Scalars['Int'];
+  projectColor?: Maybe<Scalars['String']>;
+};
+
+export type UpdateProjectInput = {
+  projectId: Scalars['ID'];
+  inactivityTimeoutSeconds: Scalars['Int'];
+  projectColor?: Maybe<Scalars['String']>;
+};
+
+export type ProjectInput = {
+  projectId: Scalars['String'];
+  inactivityTimeoutSeconds?: Maybe<Scalars['Int']>;
+  projectColor?: Maybe<Scalars['String']>;
+  hooks?: Maybe<Array<Maybe<HookInput>>>;
+};
+
+export type DeleteProjectResponse = {
+  __typename?: 'DeleteProjectResponse';
+  success: Scalars['Boolean'];
+  message: Scalars['String'];
+  projectIds: Array<Maybe<Scalars['ID']>>;
 };
 
 export type Run = {
   __typename?: 'Run';
-  completion?: Maybe<RunCompletion>;
+  runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta: RunMeta;
-  progress?: Maybe<RunProgress>;
-  runId: Scalars['ID'];
   specs: Array<RunSpec>;
+  completion?: Maybe<RunCompletion>;
+  progress?: Maybe<RunProgress>;
 };
 
 export type RunCompletion = {
@@ -433,11 +385,29 @@ export type RunCompletion = {
   inactivityTimeoutMs?: Maybe<Scalars['Int']>;
 };
 
-export type RunFeed = {
-  __typename?: 'RunFeed';
-  cursor: Scalars['String'];
-  hasMore: Scalars['Boolean'];
-  runs: Array<Run>;
+export type RunSpec = {
+  __typename?: 'RunSpec';
+  spec: Scalars['String'];
+  instanceId: Scalars['String'];
+  claimedAt?: Maybe<Scalars['String']>;
+  completedAt?: Maybe<Scalars['String']>;
+  machineId?: Maybe<Scalars['String']>;
+  tests?: Maybe<Scalars['Int']>;
+  groupId?: Maybe<Scalars['String']>;
+  results?: Maybe<RunSpecResults>;
+};
+
+export type RunSpecResults = {
+  __typename?: 'RunSpecResults';
+  error?: Maybe<Scalars['String']>;
+  retries?: Maybe<Scalars['Int']>;
+  stats: InstanceStats;
+};
+
+export type RunProgress = {
+  __typename?: 'RunProgress';
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  groups: Array<RunGroupProgress>;
 };
 
 export type RunGroupProgress = {
@@ -449,159 +419,179 @@ export type RunGroupProgress = {
 
 export type RunGroupProgressInstances = {
   __typename?: 'RunGroupProgressInstances';
+  overall: Scalars['Int'];
   claimed: Scalars['Int'];
   complete: Scalars['Int'];
-  failures: Scalars['Int'];
-  overall: Scalars['Int'];
   passes: Scalars['Int'];
+  failures: Scalars['Int'];
 };
 
 export type RunGroupProgressTests = {
   __typename?: 'RunGroupProgressTests';
-  failures: Scalars['Int'];
   overall: Scalars['Int'];
   passes: Scalars['Int'];
+  failures: Scalars['Int'];
+  skipped: Scalars['Int'];
   pending: Scalars['Int'];
   retries: Scalars['Int'];
-  skipped: Scalars['Int'];
+};
+
+export type Commit = {
+  __typename?: 'Commit';
+  sha?: Maybe<Scalars['String']>;
+  branch?: Maybe<Scalars['String']>;
+  authorName?: Maybe<Scalars['String']>;
+  authorEmail?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  remoteOrigin?: Maybe<Scalars['String']>;
 };
 
 export type RunMeta = {
   __typename?: 'RunMeta';
   ciBuildId: Scalars['String'];
-  commit?: Maybe<Commit>;
   projectId: Scalars['String'];
+  commit?: Maybe<Commit>;
 };
 
-export type RunProgress = {
-  __typename?: 'RunProgress';
-  groups: Array<RunGroupProgress>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-};
-
-export type RunSpec = {
-  __typename?: 'RunSpec';
-  claimedAt?: Maybe<Scalars['String']>;
-  completedAt?: Maybe<Scalars['String']>;
-  groupId?: Maybe<Scalars['String']>;
-  instanceId: Scalars['String'];
-  machineId?: Maybe<Scalars['String']>;
-  results?: Maybe<RunSpecResults>;
-  spec: Scalars['String'];
-};
-
-export type RunSpecResults = {
-  __typename?: 'RunSpecResults';
-  error?: Maybe<Scalars['String']>;
-  retries?: Maybe<Scalars['Int']>;
-  stats: InstanceStats;
-};
-
-export type SlackHook = {
-  __typename?: 'SlackHook';
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['SlackHookType'];
-  projectId: Scalars['ID'];
-  slackBranchFilter?: Maybe<Array<Scalars['String']>>;
-  slackResultFilter?: Maybe<Scalars['SlackResultFilter']>;
-  url: Scalars['String'];
-};
-
-export type SpecStats = {
-  __typename?: 'SpecStats';
-  avgWallClockDuration: Scalars['Int'];
-  count: Scalars['Int'];
-  spec: Scalars['String'];
-};
-
-export type TeamsHook = {
-  __typename?: 'TeamsHook';
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['TeamsHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type TestAttempt = {
-  __typename?: 'TestAttempt';
-  error?: Maybe<TestError>;
-  state?: Maybe<Scalars['String']>;
-  wallClockDuration?: Maybe<Scalars['Int']>;
-  wallClockStartedAt?: Maybe<Scalars['String']>;
-};
-
-export type TestError = {
-  __typename?: 'TestError';
+export type ResetInstanceResponse = {
+  __typename?: 'ResetInstanceResponse';
+  instanceId: Scalars['ID'];
   message: Scalars['String'];
-  name: Scalars['String'];
-  stack: Scalars['String'];
+  success?: Maybe<Scalars['Boolean']>;
+};
+
+export type RunFeed = {
+  __typename?: 'RunFeed';
+  cursor: Scalars['String'];
+  hasMore: Scalars['Boolean'];
+  runs: Array<Run>;
+};
+
+export type Instance = {
+  __typename?: 'Instance';
+  runId: Scalars['ID'];
+  run: Run;
+  spec: Scalars['String'];
+  groupId: Scalars['String'];
+  projectId: Scalars['String'];
+  instanceId: Scalars['ID'];
+  results?: Maybe<InstanceResults>;
+};
+
+export type InstanceResults = {
+  __typename?: 'InstanceResults';
+  stats: InstanceStats;
+  tests?: Maybe<Array<InstanceTest>>;
+  error?: Maybe<Scalars['String']>;
+  stdout?: Maybe<Scalars['String']>;
+  screenshots: Array<InstanceScreeshot>;
+  cypressConfig?: Maybe<CypressConfig>;
+  reporterStats?: Maybe<ReporterStats>;
+  videoUrl?: Maybe<Scalars['String']>;
+};
+
+export type InstanceStats = {
+  __typename?: 'InstanceStats';
+  suites: Scalars['Int'];
+  tests: Scalars['Int'];
+  passes: Scalars['Int'];
+  pending: Scalars['Int'];
+  skipped: Scalars['Int'];
+  failures: Scalars['Int'];
+  wallClockStartedAt: Scalars['String'];
+  wallClockEndedAt: Scalars['String'];
+  wallClockDuration: Scalars['Int'];
+};
+
+export type CypressConfig = {
+  __typename?: 'CypressConfig';
+  video: Scalars['Boolean'];
+  videoUploadOnPasses: Scalars['Boolean'];
+};
+
+export type InstanceScreeshot = {
+  __typename?: 'InstanceScreeshot';
+  screenshotId: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  testId: Scalars['String'];
+  takenAt: Scalars['String'];
+  height: Scalars['Int'];
+  width: Scalars['Int'];
+  screenshotURL?: Maybe<Scalars['String']>;
+};
+
+export type ReporterStats = {
+  __typename?: 'ReporterStats';
+  suites?: Maybe<Scalars['Int']>;
+  tests?: Maybe<Scalars['Int']>;
+  passes?: Maybe<Scalars['Int']>;
+  pending?: Maybe<Scalars['Int']>;
+  failures?: Maybe<Scalars['Int']>;
+  start?: Maybe<Scalars['String']>;
+  end?: Maybe<Scalars['String']>;
+  duration?: Maybe<Scalars['Int']>;
 };
 
 export enum TestState {
   Failed = 'failed',
   Passed = 'passed',
   Pending = 'pending',
-  Skipped = 'skipped'
+  Skipped = 'skipped',
 }
 
-export type UpdateBitbucketHookInput = {
-  bitbucketBuildName?: InputMaybe<Scalars['String']>;
-  bitbucketToken?: InputMaybe<Scalars['String']>;
-  bitbucketUsername: Scalars['String'];
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url?: InputMaybe<Scalars['String']>;
+export type InstanceTest = {
+  __typename?: 'InstanceTest';
+  testId: Scalars['String'];
+  title: Array<Scalars['String']>;
+  state: TestState;
+  body?: Maybe<Scalars['String']>;
+  displayError?: Maybe<Scalars['String']>;
+  attempts: Array<TestAttempt>;
 };
 
-export type UpdateGenericHookInput = {
-  headers?: InputMaybe<Scalars['String']>;
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
+export type TestError = {
+  __typename?: 'TestError';
+  name: Scalars['String'];
+  message: Scalars['String'];
+  stack: Scalars['String'];
 };
 
-export type UpdateGithubHookInput = {
-  githubContext?: InputMaybe<Scalars['String']>;
-  githubToken?: InputMaybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
+export type TestAttempt = {
+  __typename?: 'TestAttempt';
+  state?: Maybe<Scalars['String']>;
+  error?: Maybe<TestError>;
+  wallClockStartedAt?: Maybe<Scalars['String']>;
+  wallClockDuration?: Maybe<Scalars['Int']>;
 };
 
-export type UpdateProjectInput = {
-  inactivityTimeoutSeconds: Scalars['Int'];
-  projectColor?: InputMaybe<Scalars['String']>;
-  projectId: Scalars['ID'];
+export enum OrderingOptions {
+  Desc = 'DESC',
+  Asc = 'ASC',
+}
+
+export type Filters = {
+  key?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
+  like?: Maybe<Scalars['String']>;
 };
-
-export type UpdateSlackHookInput = {
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  slackBranchFilter?: InputMaybe<Array<Scalars['String']>>;
-  slackResultFilter?: InputMaybe<Scalars['SlackResultFilter']>;
-  url: Scalars['String'];
-};
-
-export type UpdateTeamsHookInput = {
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-
-export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -615,7 +605,7 @@ export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -624,9 +614,25 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >;
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -634,12 +640,26 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -648,11 +668,19 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -662,525 +690,977 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  BitbucketHook: ResolverTypeWrapper<BitbucketHook>;
-  BitbucketHookType: ResolverTypeWrapper<Scalars['BitbucketHookType']>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Commit: ResolverTypeWrapper<Commit>;
-  CreateBitbucketHookInput: CreateBitbucketHookInput;
-  CreateGenericHookInput: CreateGenericHookInput;
-  CreateGithubHookInput: CreateGithubHookInput;
-  CreateProjectInput: CreateProjectInput;
-  CreateSlackHookInput: CreateSlackHookInput;
-  CreateTeamsHookInput: CreateTeamsHookInput;
-  CypressConfig: ResolverTypeWrapper<CypressConfig>;
-  DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+  Mutation: ResolverTypeWrapper<{}>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
   DeleteHookInput: DeleteHookInput;
+  String: ResolverTypeWrapper<Scalars['String']>;
   DeleteHookResponse: ResolverTypeWrapper<DeleteHookResponse>;
-  DeleteProjectResponse: ResolverTypeWrapper<DeleteProjectResponse>;
-  DeleteRunResponse: ResolverTypeWrapper<DeleteRunResponse>;
-  Filters: Filters;
-  GenericHook: ResolverTypeWrapper<GenericHook>;
-  GenericHookType: ResolverTypeWrapper<Scalars['GenericHookType']>;
+  SlackHook: ResolverTypeWrapper<SlackHook>;
+  CreateSlackHookInput: CreateSlackHookInput;
+  UpdateSlackHookInput: UpdateSlackHookInput;
   GithubHook: ResolverTypeWrapper<GithubHook>;
-  GithubHookType: ResolverTypeWrapper<Scalars['GithubHookType']>;
+  CreateGithubHookInput: CreateGithubHookInput;
+  UpdateGithubHookInput: UpdateGithubHookInput;
+  BitbucketHook: ResolverTypeWrapper<BitbucketHook>;
+  CreateBitbucketHookInput: CreateBitbucketHookInput;
+  UpdateBitbucketHookInput: UpdateBitbucketHookInput;
+  TeamsHook: ResolverTypeWrapper<TeamsHook>;
+  CreateTeamsHookInput: CreateTeamsHookInput;
+  UpdateTeamsHookInput: UpdateTeamsHookInput;
+  GenericHook: ResolverTypeWrapper<GenericHook>;
+  CreateGenericHookInput: CreateGenericHookInput;
+  UpdateGenericHookInput: UpdateGenericHookInput;
   Hook: ResolverTypeWrapper<Hook>;
   HookInput: HookInput;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Instance: ResolverTypeWrapper<Instance>;
-  InstanceResults: ResolverTypeWrapper<InstanceResults>;
-  InstanceScreeshot: ResolverTypeWrapper<InstanceScreeshot>;
-  InstanceStats: ResolverTypeWrapper<InstanceStats>;
-  InstanceTest: ResolverTypeWrapper<InstanceTest>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  Mutation: ResolverTypeWrapper<{}>;
-  OrderingOptions: OrderingOptions;
-  Project: ResolverTypeWrapper<Project>;
-  ProjectInput: ProjectInput;
+  GenericHookType: ResolverTypeWrapper<Scalars['GenericHookType']>;
+  SlackHookType: ResolverTypeWrapper<Scalars['SlackHookType']>;
+  SlackResultFilter: ResolverTypeWrapper<Scalars['SlackResultFilter']>;
+  GithubHookType: ResolverTypeWrapper<Scalars['GithubHookType']>;
+  BitbucketHookType: ResolverTypeWrapper<Scalars['BitbucketHookType']>;
+  TeamsHookType: ResolverTypeWrapper<Scalars['TeamsHookType']>;
   Query: ResolverTypeWrapper<{}>;
-  ReporterStats: ResolverTypeWrapper<ReporterStats>;
-  ResetInstanceResponse: ResolverTypeWrapper<ResetInstanceResponse>;
+  DeleteRunResponse: ResolverTypeWrapper<DeleteRunResponse>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  SpecStats: ResolverTypeWrapper<SpecStats>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Project: ResolverTypeWrapper<Project>;
+  CreateProjectInput: CreateProjectInput;
+  UpdateProjectInput: UpdateProjectInput;
+  ProjectInput: ProjectInput;
+  DeleteProjectResponse: ResolverTypeWrapper<DeleteProjectResponse>;
   Run: ResolverTypeWrapper<Run>;
   RunCompletion: ResolverTypeWrapper<RunCompletion>;
-  RunFeed: ResolverTypeWrapper<RunFeed>;
+  RunSpec: ResolverTypeWrapper<RunSpec>;
+  RunSpecResults: ResolverTypeWrapper<RunSpecResults>;
+  RunProgress: ResolverTypeWrapper<RunProgress>;
   RunGroupProgress: ResolverTypeWrapper<RunGroupProgress>;
   RunGroupProgressInstances: ResolverTypeWrapper<RunGroupProgressInstances>;
   RunGroupProgressTests: ResolverTypeWrapper<RunGroupProgressTests>;
+  Commit: ResolverTypeWrapper<Commit>;
   RunMeta: ResolverTypeWrapper<RunMeta>;
-  RunProgress: ResolverTypeWrapper<RunProgress>;
-  RunSpec: ResolverTypeWrapper<RunSpec>;
-  RunSpecResults: ResolverTypeWrapper<RunSpecResults>;
-  SlackHook: ResolverTypeWrapper<SlackHook>;
-  SlackHookType: ResolverTypeWrapper<Scalars['SlackHookType']>;
-  SlackResultFilter: ResolverTypeWrapper<Scalars['SlackResultFilter']>;
-  SpecStats: ResolverTypeWrapper<SpecStats>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  TeamsHook: ResolverTypeWrapper<TeamsHook>;
-  TeamsHookType: ResolverTypeWrapper<Scalars['TeamsHookType']>;
-  TestAttempt: ResolverTypeWrapper<TestAttempt>;
-  TestError: ResolverTypeWrapper<TestError>;
+  ResetInstanceResponse: ResolverTypeWrapper<ResetInstanceResponse>;
+  RunFeed: ResolverTypeWrapper<RunFeed>;
+  Instance: ResolverTypeWrapper<Instance>;
+  InstanceResults: ResolverTypeWrapper<InstanceResults>;
+  InstanceStats: ResolverTypeWrapper<InstanceStats>;
+  CypressConfig: ResolverTypeWrapper<CypressConfig>;
+  InstanceScreeshot: ResolverTypeWrapper<InstanceScreeshot>;
+  ReporterStats: ResolverTypeWrapper<ReporterStats>;
   TestState: TestState;
-  UpdateBitbucketHookInput: UpdateBitbucketHookInput;
-  UpdateGenericHookInput: UpdateGenericHookInput;
-  UpdateGithubHookInput: UpdateGithubHookInput;
-  UpdateProjectInput: UpdateProjectInput;
-  UpdateSlackHookInput: UpdateSlackHookInput;
-  UpdateTeamsHookInput: UpdateTeamsHookInput;
+  InstanceTest: ResolverTypeWrapper<InstanceTest>;
+  TestError: ResolverTypeWrapper<TestError>;
+  TestAttempt: ResolverTypeWrapper<TestAttempt>;
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+  OrderingOptions: OrderingOptions;
+  Filters: Filters;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  BitbucketHook: BitbucketHook;
-  BitbucketHookType: Scalars['BitbucketHookType'];
-  Boolean: Scalars['Boolean'];
-  Commit: Commit;
-  CreateBitbucketHookInput: CreateBitbucketHookInput;
-  CreateGenericHookInput: CreateGenericHookInput;
-  CreateGithubHookInput: CreateGithubHookInput;
-  CreateProjectInput: CreateProjectInput;
-  CreateSlackHookInput: CreateSlackHookInput;
-  CreateTeamsHookInput: CreateTeamsHookInput;
-  CypressConfig: CypressConfig;
-  DateTime: Scalars['DateTime'];
+  Mutation: {};
+  ID: Scalars['ID'];
   DeleteHookInput: DeleteHookInput;
+  String: Scalars['String'];
   DeleteHookResponse: DeleteHookResponse;
-  DeleteProjectResponse: DeleteProjectResponse;
-  DeleteRunResponse: DeleteRunResponse;
-  Filters: Filters;
-  GenericHook: GenericHook;
-  GenericHookType: Scalars['GenericHookType'];
+  SlackHook: SlackHook;
+  CreateSlackHookInput: CreateSlackHookInput;
+  UpdateSlackHookInput: UpdateSlackHookInput;
   GithubHook: GithubHook;
-  GithubHookType: Scalars['GithubHookType'];
+  CreateGithubHookInput: CreateGithubHookInput;
+  UpdateGithubHookInput: UpdateGithubHookInput;
+  BitbucketHook: BitbucketHook;
+  CreateBitbucketHookInput: CreateBitbucketHookInput;
+  UpdateBitbucketHookInput: UpdateBitbucketHookInput;
+  TeamsHook: TeamsHook;
+  CreateTeamsHookInput: CreateTeamsHookInput;
+  UpdateTeamsHookInput: UpdateTeamsHookInput;
+  GenericHook: GenericHook;
+  CreateGenericHookInput: CreateGenericHookInput;
+  UpdateGenericHookInput: UpdateGenericHookInput;
   Hook: Hook;
   HookInput: HookInput;
-  ID: Scalars['ID'];
-  Instance: Instance;
-  InstanceResults: InstanceResults;
-  InstanceScreeshot: InstanceScreeshot;
-  InstanceStats: InstanceStats;
-  InstanceTest: InstanceTest;
-  Int: Scalars['Int'];
-  Mutation: {};
-  Project: Project;
-  ProjectInput: ProjectInput;
+  GenericHookType: Scalars['GenericHookType'];
+  SlackHookType: Scalars['SlackHookType'];
+  SlackResultFilter: Scalars['SlackResultFilter'];
+  GithubHookType: Scalars['GithubHookType'];
+  BitbucketHookType: Scalars['BitbucketHookType'];
+  TeamsHookType: Scalars['TeamsHookType'];
   Query: {};
-  ReporterStats: ReporterStats;
-  ResetInstanceResponse: ResetInstanceResponse;
+  DeleteRunResponse: DeleteRunResponse;
+  Boolean: Scalars['Boolean'];
+  SpecStats: SpecStats;
+  Int: Scalars['Int'];
+  Project: Project;
+  CreateProjectInput: CreateProjectInput;
+  UpdateProjectInput: UpdateProjectInput;
+  ProjectInput: ProjectInput;
+  DeleteProjectResponse: DeleteProjectResponse;
   Run: Run;
   RunCompletion: RunCompletion;
-  RunFeed: RunFeed;
+  RunSpec: RunSpec;
+  RunSpecResults: RunSpecResults;
+  RunProgress: RunProgress;
   RunGroupProgress: RunGroupProgress;
   RunGroupProgressInstances: RunGroupProgressInstances;
   RunGroupProgressTests: RunGroupProgressTests;
+  Commit: Commit;
   RunMeta: RunMeta;
-  RunProgress: RunProgress;
-  RunSpec: RunSpec;
-  RunSpecResults: RunSpecResults;
-  SlackHook: SlackHook;
-  SlackHookType: Scalars['SlackHookType'];
-  SlackResultFilter: Scalars['SlackResultFilter'];
-  SpecStats: SpecStats;
-  String: Scalars['String'];
-  TeamsHook: TeamsHook;
-  TeamsHookType: Scalars['TeamsHookType'];
-  TestAttempt: TestAttempt;
+  ResetInstanceResponse: ResetInstanceResponse;
+  RunFeed: RunFeed;
+  Instance: Instance;
+  InstanceResults: InstanceResults;
+  InstanceStats: InstanceStats;
+  CypressConfig: CypressConfig;
+  InstanceScreeshot: InstanceScreeshot;
+  ReporterStats: ReporterStats;
+  InstanceTest: InstanceTest;
   TestError: TestError;
-  UpdateBitbucketHookInput: UpdateBitbucketHookInput;
-  UpdateGenericHookInput: UpdateGenericHookInput;
-  UpdateGithubHookInput: UpdateGithubHookInput;
-  UpdateProjectInput: UpdateProjectInput;
-  UpdateSlackHookInput: UpdateSlackHookInput;
-  UpdateTeamsHookInput: UpdateTeamsHookInput;
+  TestAttempt: TestAttempt;
+  DateTime: Scalars['DateTime'];
+  Filters: Filters;
 };
 
-export type BitbucketHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['BitbucketHook'] = ResolversParentTypes['BitbucketHook']> = {
-  bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['BitbucketHookType'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  createBitbucketHook?: Resolver<
+    ResolversTypes['BitbucketHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateBitbucketHookArgs, 'input'>
+  >;
+  createGenericHook?: Resolver<
+    ResolversTypes['GenericHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateGenericHookArgs, 'input'>
+  >;
+  createGithubHook?: Resolver<
+    ResolversTypes['GithubHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateGithubHookArgs, 'input'>
+  >;
+  createProject?: Resolver<
+    ResolversTypes['Project'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateProjectArgs, 'project'>
+  >;
+  createSlackHook?: Resolver<
+    ResolversTypes['SlackHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateSlackHookArgs, 'input'>
+  >;
+  createTeamsHook?: Resolver<
+    ResolversTypes['TeamsHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateTeamsHookArgs, 'input'>
+  >;
+  deleteHook?: Resolver<
+    ResolversTypes['DeleteHookResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteHookArgs, 'input'>
+  >;
+  deleteProject?: Resolver<
+    ResolversTypes['DeleteProjectResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteProjectArgs, 'projectId'>
+  >;
+  deleteRun?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunArgs, 'runId'>
+  >;
+  deleteRuns?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsArgs, 'runIds'>
+  >;
+  deleteRunsInDateRange?: Resolver<
+    ResolversTypes['DeleteRunResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteRunsInDateRangeArgs, 'startDate' | 'endDate'>
+  >;
+  resetInstance?: Resolver<
+    ResolversTypes['ResetInstanceResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationResetInstanceArgs, 'instanceId'>
+  >;
+  updateBitbucketHook?: Resolver<
+    ResolversTypes['BitbucketHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateBitbucketHookArgs, 'input'>
+  >;
+  updateGenericHook?: Resolver<
+    ResolversTypes['GenericHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateGenericHookArgs, 'input'>
+  >;
+  updateGithubHook?: Resolver<
+    ResolversTypes['GithubHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateGithubHookArgs, 'input'>
+  >;
+  updateProject?: Resolver<
+    ResolversTypes['Project'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateProjectArgs, 'input'>
+  >;
+  updateSlackHook?: Resolver<
+    ResolversTypes['SlackHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateSlackHookArgs, 'input'>
+  >;
+  updateTeamsHook?: Resolver<
+    ResolversTypes['TeamsHook'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateTeamsHookArgs, 'input'>
+  >;
 };
 
-export interface BitbucketHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BitbucketHookType'], any> {
-  name: 'BitbucketHookType';
-}
-
-export type CommitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']> = {
-  authorEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  authorName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  remoteOrigin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type CypressConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']> = {
-  video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  videoUploadOnPasses?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
-  name: 'DateTime';
-}
-
-export type DeleteHookResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteHookResponse'] = ResolversParentTypes['DeleteHookResponse']> = {
-  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+export type DeleteHookResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteHookResponse'] = ResolversParentTypes['DeleteHookResponse']
+> = {
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type DeleteProjectResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteProjectResponse'] = ResolversParentTypes['DeleteProjectResponse']> = {
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  projectIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type DeleteRunResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']> = {
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  runIds?: Resolver<Array<Maybe<ResolversTypes['ID']>>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type GenericHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['GenericHook'] = ResolversParentTypes['GenericHook']> = {
-  headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['GenericHookType'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
-export interface GenericHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GenericHookType'], any> {
+export type SlackHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SlackHook'] = ResolversParentTypes['SlackHook']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hookType?: Resolver<ResolversTypes['SlackHookType'], ParentType, ContextType>;
+  hookEvents?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackResultFilter?: Resolver<
+    Maybe<ResolversTypes['SlackResultFilter']>,
+    ParentType,
+    ContextType
+  >;
+  slackBranchFilter?: Resolver<
+    Maybe<Array<ResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type GithubHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['GithubHook'] = ResolversParentTypes['GithubHook']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['GithubHookType'],
+    ParentType,
+    ContextType
+  >;
+  githubToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  githubContext?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type BitbucketHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['BitbucketHook'] = ResolversParentTypes['BitbucketHook']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['BitbucketHookType'],
+    ParentType,
+    ContextType
+  >;
+  bitbucketUsername?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketBuildName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type TeamsHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TeamsHook'] = ResolversParentTypes['TeamsHook']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hookType?: Resolver<ResolversTypes['TeamsHookType'], ParentType, ContextType>;
+  hookEvents?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type GenericHookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['GenericHook'] = ResolversParentTypes['GenericHook']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hookType?: Resolver<
+    ResolversTypes['GenericHookType'],
+    ParentType,
+    ContextType
+  >;
+  hookEvents?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type HookResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Hook'] = ResolversParentTypes['Hook']
+> = {
+  hookId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hookEvents?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
+  hookType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  githubToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  githubContext?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketUsername?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketToken?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  bitbucketBuildName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackResultFilter?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  slackBranchFilter?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['String']>>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export interface GenericHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['GenericHookType'], any> {
   name: 'GenericHookType';
 }
 
-export type GithubHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['GithubHook'] = ResolversParentTypes['GithubHook']> = {
-  githubContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['GithubHookType'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export interface GithubHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
-  name: 'GithubHookType';
-}
-
-export type HookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Hook'] = ResolversParentTypes['Hook']> = {
-  bitbucketBuildName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  bitbucketUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubContext?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  headers?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookEvents?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  hookId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hookType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  slackBranchFilter?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  slackResultFilter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type InstanceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']> = {
-  groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['InstanceResults']>, ParentType, ContextType>;
-  run?: Resolver<ResolversTypes['Run'], ParentType, ContextType>;
-  runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type InstanceResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']> = {
-  cypressConfig?: Resolver<Maybe<ResolversTypes['CypressConfig']>, ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  reporterStats?: Resolver<Maybe<ResolversTypes['ReporterStats']>, ParentType, ContextType>;
-  screenshots?: Resolver<Array<ResolversTypes['InstanceScreeshot']>, ParentType, ContextType>;
-  stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  tests?: Resolver<Maybe<Array<ResolversTypes['InstanceTest']>>, ParentType, ContextType>;
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type InstanceScreeshotResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']> = {
-  height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  screenshotURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type InstanceStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']> = {
-  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  skipped?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  suites?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  tests?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  wallClockDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  wallClockEndedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type InstanceTestResolvers<ContextType = any, ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']> = {
-  attempts?: Resolver<Array<ResolversTypes['TestAttempt']>, ParentType, ContextType>;
-  body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  displayError?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  state?: Resolver<ResolversTypes['TestState'], ParentType, ContextType>;
-  testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  title?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  createBitbucketHook?: Resolver<ResolversTypes['BitbucketHook'], ParentType, ContextType, RequireFields<MutationCreateBitbucketHookArgs, 'input'>>;
-  createGenericHook?: Resolver<ResolversTypes['GenericHook'], ParentType, ContextType, RequireFields<MutationCreateGenericHookArgs, 'input'>>;
-  createGithubHook?: Resolver<ResolversTypes['GithubHook'], ParentType, ContextType, RequireFields<MutationCreateGithubHookArgs, 'input'>>;
-  createProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationCreateProjectArgs, 'project'>>;
-  createSlackHook?: Resolver<ResolversTypes['SlackHook'], ParentType, ContextType, RequireFields<MutationCreateSlackHookArgs, 'input'>>;
-  createTeamsHook?: Resolver<ResolversTypes['TeamsHook'], ParentType, ContextType, RequireFields<MutationCreateTeamsHookArgs, 'input'>>;
-  deleteHook?: Resolver<ResolversTypes['DeleteHookResponse'], ParentType, ContextType, RequireFields<MutationDeleteHookArgs, 'input'>>;
-  deleteProject?: Resolver<ResolversTypes['DeleteProjectResponse'], ParentType, ContextType, RequireFields<MutationDeleteProjectArgs, 'projectId'>>;
-  deleteRun?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunArgs, 'runId'>>;
-  deleteRuns?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsArgs, 'runIds'>>;
-  deleteRunsInDateRange?: Resolver<ResolversTypes['DeleteRunResponse'], ParentType, ContextType, RequireFields<MutationDeleteRunsInDateRangeArgs, 'endDate' | 'startDate'>>;
-  resetInstance?: Resolver<ResolversTypes['ResetInstanceResponse'], ParentType, ContextType, RequireFields<MutationResetInstanceArgs, 'instanceId'>>;
-  updateBitbucketHook?: Resolver<ResolversTypes['BitbucketHook'], ParentType, ContextType, RequireFields<MutationUpdateBitbucketHookArgs, 'input'>>;
-  updateGenericHook?: Resolver<ResolversTypes['GenericHook'], ParentType, ContextType, RequireFields<MutationUpdateGenericHookArgs, 'input'>>;
-  updateGithubHook?: Resolver<ResolversTypes['GithubHook'], ParentType, ContextType, RequireFields<MutationUpdateGithubHookArgs, 'input'>>;
-  updateProject?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<MutationUpdateProjectArgs, 'input'>>;
-  updateSlackHook?: Resolver<ResolversTypes['SlackHook'], ParentType, ContextType, RequireFields<MutationUpdateSlackHookArgs, 'input'>>;
-  updateTeamsHook?: Resolver<ResolversTypes['TeamsHook'], ParentType, ContextType, RequireFields<MutationUpdateTeamsHookArgs, 'input'>>;
-};
-
-export type ProjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']> = {
-  hooks?: Resolver<Array<ResolversTypes['Hook']>, ParentType, ContextType>;
-  inactivityTimeoutSeconds?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  projectColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;
-  project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'id'>>;
-  projects?: Resolver<Array<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectsArgs, 'filters' | 'orderDirection'>>;
-  run?: Resolver<Maybe<ResolversTypes['Run']>, ParentType, ContextType, RequireFields<QueryRunArgs, 'id'>>;
-  runFeed?: Resolver<ResolversTypes['RunFeed'], ParentType, ContextType, RequireFields<QueryRunFeedArgs, 'filters'>>;
-  runs?: Resolver<Array<Maybe<ResolversTypes['Run']>>, ParentType, ContextType, RequireFields<QueryRunsArgs, 'cursor' | 'filters' | 'orderDirection'>>;
-  specStats?: Resolver<Maybe<ResolversTypes['SpecStats']>, ParentType, ContextType, RequireFields<QuerySpecStatsArgs, 'filters' | 'spec'>>;
-};
-
-export type ReporterStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']> = {
-  duration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  end?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  failures?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  pending?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  start?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ResetInstanceResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['ResetInstanceResponse'] = ResolversParentTypes['ResetInstanceResponse']> = {
-  instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunResolvers<ContextType = any, ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']> = {
-  completion?: Resolver<Maybe<ResolversTypes['RunCompletion']>, ParentType, ContextType>;
-  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
-  meta?: Resolver<ResolversTypes['RunMeta'], ParentType, ContextType>;
-  progress?: Resolver<Maybe<ResolversTypes['RunProgress']>, ParentType, ContextType>;
-  runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  specs?: Resolver<Array<ResolversTypes['RunSpec']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunCompletionResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunCompletion'] = ResolversParentTypes['RunCompletion']> = {
-  completed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  inactivityTimeoutMs?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunFeedResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunGroupProgressResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunGroupProgress'] = ResolversParentTypes['RunGroupProgress']> = {
-  groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  instances?: Resolver<ResolversTypes['RunGroupProgressInstances'], ParentType, ContextType>;
-  tests?: Resolver<ResolversTypes['RunGroupProgressTests'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunGroupProgressInstancesResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunGroupProgressInstances'] = ResolversParentTypes['RunGroupProgressInstances']> = {
-  claimed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  complete?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  overall?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunGroupProgressTestsResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunGroupProgressTests'] = ResolversParentTypes['RunGroupProgressTests']> = {
-  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  overall?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  retries?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  skipped?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunMetaResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']> = {
-  ciBuildId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunProgressResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunProgress'] = ResolversParentTypes['RunProgress']> = {
-  groups?: Resolver<Array<ResolversTypes['RunGroupProgress']>, ParentType, ContextType>;
-  updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunSpecResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']> = {
-  claimedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  completedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  machineId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  results?: Resolver<Maybe<ResolversTypes['RunSpecResults']>, ParentType, ContextType>;
-  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type RunSpecResultsResolvers<ContextType = any, ParentType extends ResolversParentTypes['RunSpecResults'] = ResolversParentTypes['RunSpecResults']> = {
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  retries?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type SlackHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['SlackHook'] = ResolversParentTypes['SlackHook']> = {
-  hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['SlackHookType'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  slackBranchFilter?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  slackResultFilter?: Resolver<Maybe<ResolversTypes['SlackResultFilter']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export interface SlackHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackHookType'], any> {
+export interface SlackHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['SlackHookType'], any> {
   name: 'SlackHookType';
 }
 
-export interface SlackResultFilterScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['SlackResultFilter'], any> {
+export interface SlackResultFilterScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['SlackResultFilter'], any> {
   name: 'SlackResultFilter';
 }
 
-export type SpecStatsResolvers<ContextType = any, ParentType extends ResolversParentTypes['SpecStats'] = ResolversParentTypes['SpecStats']> = {
-  avgWallClockDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
+export interface GithubHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['GithubHookType'], any> {
+  name: 'GithubHookType';
+}
 
-export type TeamsHookResolvers<ContextType = any, ParentType extends ResolversParentTypes['TeamsHook'] = ResolversParentTypes['TeamsHook']> = {
-  hookEvents?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  hookId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  hookType?: Resolver<ResolversTypes['TeamsHookType'], ParentType, ContextType>;
-  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
+export interface BitbucketHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['BitbucketHookType'], any> {
+  name: 'BitbucketHookType';
+}
 
-export interface TeamsHookTypeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['TeamsHookType'], any> {
+export interface TeamsHookTypeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['TeamsHookType'], any> {
   name: 'TeamsHookType';
 }
 
-export type TestAttemptResolvers<ContextType = any, ParentType extends ResolversParentTypes['TestAttempt'] = ResolversParentTypes['TestAttempt']> = {
-  error?: Resolver<Maybe<ResolversTypes['TestError']>, ParentType, ContextType>;
-  state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  wallClockDuration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  wallClockStartedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  projects?: Resolver<
+    Array<ResolversTypes['Project']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryProjectsArgs, 'orderDirection' | 'filters'>
+  >;
+  project?: Resolver<
+    Maybe<ResolversTypes['Project']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryProjectArgs, 'id'>
+  >;
+  runs?: Resolver<
+    Array<Maybe<ResolversTypes['Run']>>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunsArgs, 'orderDirection' | 'cursor' | 'filters'>
+  >;
+  runFeed?: Resolver<
+    ResolversTypes['RunFeed'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunFeedArgs, 'filters'>
+  >;
+  run?: Resolver<
+    Maybe<ResolversTypes['Run']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRunArgs, 'id'>
+  >;
+  instance?: Resolver<
+    Maybe<ResolversTypes['Instance']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryInstanceArgs, 'id'>
+  >;
+  specStats?: Resolver<
+    Maybe<ResolversTypes['SpecStats']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySpecStatsArgs, 'spec' | 'filters'>
+  >;
 };
 
-export type TestErrorResolvers<ContextType = any, ParentType extends ResolversParentTypes['TestError'] = ResolversParentTypes['TestError']> = {
+export type DeleteRunResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteRunResponse'] = ResolversParentTypes['DeleteRunResponse']
+> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  stack?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  runIds?: Resolver<
+    Array<Maybe<ResolversTypes['ID']>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
+
+export type SpecStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SpecStats'] = ResolversParentTypes['SpecStats']
+> = {
+  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  avgWallClockDuration?: Resolver<
+    ResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >;
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type ProjectResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']
+> = {
+  projectId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  hooks?: Resolver<Array<ResolversTypes['Hook']>, ParentType, ContextType>;
+  inactivityTimeoutSeconds?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
+  projectColor?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type DeleteProjectResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['DeleteProjectResponse'] = ResolversParentTypes['DeleteProjectResponse']
+> = {
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  projectIds?: Resolver<
+    Array<Maybe<ResolversTypes['ID']>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Run'] = ResolversParentTypes['Run']
+> = {
+  runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  meta?: Resolver<ResolversTypes['RunMeta'], ParentType, ContextType>;
+  specs?: Resolver<Array<ResolversTypes['RunSpec']>, ParentType, ContextType>;
+  completion?: Resolver<
+    Maybe<ResolversTypes['RunCompletion']>,
+    ParentType,
+    ContextType
+  >;
+  progress?: Resolver<
+    Maybe<ResolversTypes['RunProgress']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunCompletionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunCompletion'] = ResolversParentTypes['RunCompletion']
+> = {
+  completed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  inactivityTimeoutMs?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunSpecResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunSpec'] = ResolversParentTypes['RunSpec']
+> = {
+  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  instanceId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  claimedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  completedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  machineId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  groupId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  results?: Resolver<
+    Maybe<ResolversTypes['RunSpecResults']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunSpecResultsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunSpecResults'] = ResolversParentTypes['RunSpecResults']
+> = {
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  retries?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunProgressResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunProgress'] = ResolversParentTypes['RunProgress']
+> = {
+  updatedAt?: Resolver<
+    Maybe<ResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >;
+  groups?: Resolver<
+    Array<ResolversTypes['RunGroupProgress']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunGroupProgressResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunGroupProgress'] = ResolversParentTypes['RunGroupProgress']
+> = {
+  groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  instances?: Resolver<
+    ResolversTypes['RunGroupProgressInstances'],
+    ParentType,
+    ContextType
+  >;
+  tests?: Resolver<
+    ResolversTypes['RunGroupProgressTests'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunGroupProgressInstancesResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunGroupProgressInstances'] = ResolversParentTypes['RunGroupProgressInstances']
+> = {
+  overall?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  claimed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  complete?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunGroupProgressTestsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunGroupProgressTests'] = ResolversParentTypes['RunGroupProgressTests']
+> = {
+  overall?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  skipped?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  retries?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type CommitResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Commit'] = ResolversParentTypes['Commit']
+> = {
+  sha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authorName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  authorEmail?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  remoteOrigin?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunMetaResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunMeta'] = ResolversParentTypes['RunMeta']
+> = {
+  ciBuildId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type ResetInstanceResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ResetInstanceResponse'] = ResolversParentTypes['ResetInstanceResponse']
+> = {
+  instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type RunFeedResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['RunFeed'] = ResolversParentTypes['RunFeed']
+> = {
+  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  runs?: Resolver<Array<ResolversTypes['Run']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type InstanceResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
+> = {
+  runId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  run?: Resolver<ResolversTypes['Run'], ParentType, ContextType>;
+  spec?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  results?: Resolver<
+    Maybe<ResolversTypes['InstanceResults']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type InstanceResultsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceResults'] = ResolversParentTypes['InstanceResults']
+> = {
+  stats?: Resolver<ResolversTypes['InstanceStats'], ParentType, ContextType>;
+  tests?: Resolver<
+    Maybe<Array<ResolversTypes['InstanceTest']>>,
+    ParentType,
+    ContextType
+  >;
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  stdout?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  screenshots?: Resolver<
+    Array<ResolversTypes['InstanceScreeshot']>,
+    ParentType,
+    ContextType
+  >;
+  cypressConfig?: Resolver<
+    Maybe<ResolversTypes['CypressConfig']>,
+    ParentType,
+    ContextType
+  >;
+  reporterStats?: Resolver<
+    Maybe<ResolversTypes['ReporterStats']>,
+    ParentType,
+    ContextType
+  >;
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type InstanceStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceStats'] = ResolversParentTypes['InstanceStats']
+> = {
+  suites?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  tests?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  passes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  pending?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  skipped?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  failures?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    ResolversTypes['String'],
+    ParentType,
+    ContextType
+  >;
+  wallClockEndedAt?: Resolver<
+    ResolversTypes['String'],
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type CypressConfigResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['CypressConfig'] = ResolversParentTypes['CypressConfig']
+> = {
+  video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  videoUploadOnPasses?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type InstanceScreeshotResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceScreeshot'] = ResolversParentTypes['InstanceScreeshot']
+> = {
+  screenshotId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  takenAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  screenshotURL?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type ReporterStatsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ReporterStats'] = ResolversParentTypes['ReporterStats']
+> = {
+  suites?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  tests?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  passes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  pending?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  failures?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  start?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  end?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  duration?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type InstanceTestResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InstanceTest'] = ResolversParentTypes['InstanceTest']
+> = {
+  testId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  state?: Resolver<ResolversTypes['TestState'], ParentType, ContextType>;
+  body?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayError?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  attempts?: Resolver<
+    Array<ResolversTypes['TestAttempt']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type TestErrorResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TestError'] = ResolversParentTypes['TestError']
+> = {
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stack?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type TestAttemptResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TestAttempt'] = ResolversParentTypes['TestAttempt']
+> = {
+  state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['TestError']>, ParentType, ContextType>;
+  wallClockStartedAt?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  wallClockDuration?: Resolver<
+    Maybe<ResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export interface DateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime';
+}
 
 export type Resolvers<ContextType = any> = {
-  BitbucketHook?: BitbucketHookResolvers<ContextType>;
-  BitbucketHookType?: GraphQLScalarType;
-  Commit?: CommitResolvers<ContextType>;
-  CypressConfig?: CypressConfigResolvers<ContextType>;
-  DateTime?: GraphQLScalarType;
-  DeleteHookResponse?: DeleteHookResponseResolvers<ContextType>;
-  DeleteProjectResponse?: DeleteProjectResponseResolvers<ContextType>;
-  DeleteRunResponse?: DeleteRunResponseResolvers<ContextType>;
-  GenericHook?: GenericHookResolvers<ContextType>;
-  GenericHookType?: GraphQLScalarType;
-  GithubHook?: GithubHookResolvers<ContextType>;
-  GithubHookType?: GraphQLScalarType;
-  Hook?: HookResolvers<ContextType>;
-  Instance?: InstanceResolvers<ContextType>;
-  InstanceResults?: InstanceResultsResolvers<ContextType>;
-  InstanceScreeshot?: InstanceScreeshotResolvers<ContextType>;
-  InstanceStats?: InstanceStatsResolvers<ContextType>;
-  InstanceTest?: InstanceTestResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  Project?: ProjectResolvers<ContextType>;
+  DeleteHookResponse?: DeleteHookResponseResolvers<ContextType>;
+  SlackHook?: SlackHookResolvers<ContextType>;
+  GithubHook?: GithubHookResolvers<ContextType>;
+  BitbucketHook?: BitbucketHookResolvers<ContextType>;
+  TeamsHook?: TeamsHookResolvers<ContextType>;
+  GenericHook?: GenericHookResolvers<ContextType>;
+  Hook?: HookResolvers<ContextType>;
+  GenericHookType?: GraphQLScalarType;
+  SlackHookType?: GraphQLScalarType;
+  SlackResultFilter?: GraphQLScalarType;
+  GithubHookType?: GraphQLScalarType;
+  BitbucketHookType?: GraphQLScalarType;
+  TeamsHookType?: GraphQLScalarType;
   Query?: QueryResolvers<ContextType>;
-  ReporterStats?: ReporterStatsResolvers<ContextType>;
-  ResetInstanceResponse?: ResetInstanceResponseResolvers<ContextType>;
+  DeleteRunResponse?: DeleteRunResponseResolvers<ContextType>;
+  SpecStats?: SpecStatsResolvers<ContextType>;
+  Project?: ProjectResolvers<ContextType>;
+  DeleteProjectResponse?: DeleteProjectResponseResolvers<ContextType>;
   Run?: RunResolvers<ContextType>;
   RunCompletion?: RunCompletionResolvers<ContextType>;
-  RunFeed?: RunFeedResolvers<ContextType>;
+  RunSpec?: RunSpecResolvers<ContextType>;
+  RunSpecResults?: RunSpecResultsResolvers<ContextType>;
+  RunProgress?: RunProgressResolvers<ContextType>;
   RunGroupProgress?: RunGroupProgressResolvers<ContextType>;
   RunGroupProgressInstances?: RunGroupProgressInstancesResolvers<ContextType>;
   RunGroupProgressTests?: RunGroupProgressTestsResolvers<ContextType>;
+  Commit?: CommitResolvers<ContextType>;
   RunMeta?: RunMetaResolvers<ContextType>;
-  RunProgress?: RunProgressResolvers<ContextType>;
-  RunSpec?: RunSpecResolvers<ContextType>;
-  RunSpecResults?: RunSpecResultsResolvers<ContextType>;
-  SlackHook?: SlackHookResolvers<ContextType>;
-  SlackHookType?: GraphQLScalarType;
-  SlackResultFilter?: GraphQLScalarType;
-  SpecStats?: SpecStatsResolvers<ContextType>;
-  TeamsHook?: TeamsHookResolvers<ContextType>;
-  TeamsHookType?: GraphQLScalarType;
-  TestAttempt?: TestAttemptResolvers<ContextType>;
+  ResetInstanceResponse?: ResetInstanceResponseResolvers<ContextType>;
+  RunFeed?: RunFeedResolvers<ContextType>;
+  Instance?: InstanceResolvers<ContextType>;
+  InstanceResults?: InstanceResultsResolvers<ContextType>;
+  InstanceStats?: InstanceStatsResolvers<ContextType>;
+  CypressConfig?: CypressConfigResolvers<ContextType>;
+  InstanceScreeshot?: InstanceScreeshotResolvers<ContextType>;
+  ReporterStats?: ReporterStatsResolvers<ContextType>;
+  InstanceTest?: InstanceTestResolvers<ContextType>;
   TestError?: TestErrorResolvers<ContextType>;
+  TestAttempt?: TestAttemptResolvers<ContextType>;
+  DateTime?: GraphQLScalarType;
 };
 
+/**
+ * @deprecated
+ * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+ */
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/packages/dashboard/src/components/common/runState.tsx
+++ b/packages/dashboard/src/components/common/runState.tsx
@@ -1,4 +1,5 @@
 import {
+  AccessTime,
   CheckCircleOutline as CheckCircleOutlineIcon,
   ErrorOutline as ErrorOutlineIcon,
   Flaky as FlakyIcon,
@@ -19,6 +20,21 @@ export const TestSuccessChip: TestChipComponent = (props) => {
         shade={!value ? 300 : undefined}
         label={<Pad number={value} />}
         icon={CheckCircleOutlineIcon}
+      />
+    </Tooltip>
+  );
+};
+
+export const TestPendingChip: TestChipComponent = (props) => {
+  const { value } = props;
+
+  return (
+    <Tooltip title="Pending Tests" arrow>
+      <Chip
+        color={value ? 'cyan' : 'grey'}
+        shade={!value ? 300 : undefined}
+        label={<Pad number={value} />}
+        icon={AccessTime}
       />
     </Tooltip>
   );

--- a/packages/dashboard/src/components/common/specState.tsx
+++ b/packages/dashboard/src/components/common/specState.tsx
@@ -29,8 +29,9 @@ export const getInstanceState: GetInstanceState = (data) => {
     return 'pending';
   }
 
-  // Keep before "no tests"
-  if (stats.failures > 0 || stats.skipped > 0) {
+  // Keep before "no tests" need to have actual failures to qualify as failed
+  // mocha allows you to skip tests on purpose, and cypress (and sorry cypress) should respect this
+  if (stats.failures > 0) {
     return 'failed';
   }
 

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -1,11 +1,13 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
-export type InputMaybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-const defaultOptions = {} as const;
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -13,206 +15,13 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  BitbucketHookType: any;
-  DateTime: string;
   GenericHookType: any;
-  GithubHookType: any;
   SlackHookType: any;
   SlackResultFilter: any;
+  GithubHookType: any;
+  BitbucketHookType: any;
   TeamsHookType: any;
-};
-
-export type BitbucketHook = {
-  __typename?: 'BitbucketHook';
-  bitbucketBuildName: Maybe<Scalars['String']>;
-  bitbucketToken: Maybe<Scalars['String']>;
-  bitbucketUsername: Maybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['BitbucketHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type Commit = {
-  __typename?: 'Commit';
-  authorEmail: Maybe<Scalars['String']>;
-  authorName: Maybe<Scalars['String']>;
-  branch: Maybe<Scalars['String']>;
-  message: Maybe<Scalars['String']>;
-  remoteOrigin: Maybe<Scalars['String']>;
-  sha: Maybe<Scalars['String']>;
-};
-
-export type CreateBitbucketHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateGenericHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateGithubHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CreateProjectInput = {
-  inactivityTimeoutSeconds: Scalars['Int'];
-  projectColor: InputMaybe<Scalars['String']>;
-  projectId: Scalars['ID'];
-};
-
-export type CreateSlackHookInput = {
-  projectId: Scalars['ID'];
-  slackResultFilter: InputMaybe<Scalars['SlackResultFilter']>;
-};
-
-export type CreateTeamsHookInput = {
-  projectId: Scalars['ID'];
-};
-
-export type CypressConfig = {
-  __typename?: 'CypressConfig';
-  video: Scalars['Boolean'];
-  videoUploadOnPasses: Scalars['Boolean'];
-};
-
-export type DeleteHookInput = {
-  hookId: Scalars['ID'];
-  projectId: Scalars['String'];
-};
-
-export type DeleteHookResponse = {
-  __typename?: 'DeleteHookResponse';
-  hookId: Scalars['ID'];
-  projectId: Scalars['String'];
-};
-
-export type DeleteProjectResponse = {
-  __typename?: 'DeleteProjectResponse';
-  message: Scalars['String'];
-  projectIds: Array<Maybe<Scalars['ID']>>;
-  success: Scalars['Boolean'];
-};
-
-export type DeleteRunResponse = {
-  __typename?: 'DeleteRunResponse';
-  message: Scalars['String'];
-  runIds: Array<Maybe<Scalars['ID']>>;
-  success: Scalars['Boolean'];
-};
-
-export type Filters = {
-  key: InputMaybe<Scalars['String']>;
-  like: InputMaybe<Scalars['String']>;
-  value: InputMaybe<Scalars['String']>;
-};
-
-export type GenericHook = {
-  __typename?: 'GenericHook';
-  headers: Maybe<Scalars['String']>;
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['GenericHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type GithubHook = {
-  __typename?: 'GithubHook';
-  githubContext: Maybe<Scalars['String']>;
-  githubToken: Maybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['GithubHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type Hook = {
-  __typename?: 'Hook';
-  bitbucketBuildName: Maybe<Scalars['String']>;
-  bitbucketToken: Maybe<Scalars['String']>;
-  bitbucketUsername: Maybe<Scalars['String']>;
-  githubContext: Maybe<Scalars['String']>;
-  githubToken: Maybe<Scalars['String']>;
-  headers: Maybe<Scalars['String']>;
-  hookEvents: Maybe<Array<Maybe<Scalars['String']>>>;
-  hookId: Maybe<Scalars['String']>;
-  hookType: Maybe<Scalars['String']>;
-  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
-  slackResultFilter: Maybe<Scalars['String']>;
-  url: Maybe<Scalars['String']>;
-};
-
-export type HookInput = {
-  bitbucketBuildName: InputMaybe<Scalars['String']>;
-  bitbucketToken: InputMaybe<Scalars['String']>;
-  bitbucketUsername: InputMaybe<Scalars['String']>;
-  githubContext: InputMaybe<Scalars['String']>;
-  githubToken: InputMaybe<Scalars['String']>;
-  headers: InputMaybe<Scalars['String']>;
-  hookEvents: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  hookId: InputMaybe<Scalars['String']>;
-  hookType: InputMaybe<Scalars['String']>;
-  slackBranchFilter: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  slackResultFilter: InputMaybe<Scalars['String']>;
-  url: Scalars['String'];
-};
-
-export type Instance = {
-  __typename?: 'Instance';
-  groupId: Scalars['String'];
-  instanceId: Scalars['ID'];
-  projectId: Scalars['String'];
-  results: Maybe<InstanceResults>;
-  run: Run;
-  runId: Scalars['ID'];
-  spec: Scalars['String'];
-};
-
-export type InstanceResults = {
-  __typename?: 'InstanceResults';
-  cypressConfig: Maybe<CypressConfig>;
-  error: Maybe<Scalars['String']>;
-  reporterStats: Maybe<ReporterStats>;
-  screenshots: Array<InstanceScreeshot>;
-  stats: InstanceStats;
-  stdout: Maybe<Scalars['String']>;
-  tests: Maybe<Array<InstanceTest>>;
-  videoUrl: Maybe<Scalars['String']>;
-};
-
-export type InstanceScreeshot = {
-  __typename?: 'InstanceScreeshot';
-  height: Scalars['Int'];
-  name: Maybe<Scalars['String']>;
-  screenshotId: Scalars['String'];
-  screenshotURL: Maybe<Scalars['String']>;
-  takenAt: Scalars['String'];
-  testId: Scalars['String'];
-  width: Scalars['Int'];
-};
-
-export type InstanceStats = {
-  __typename?: 'InstanceStats';
-  failures: Scalars['Int'];
-  passes: Scalars['Int'];
-  pending: Scalars['Int'];
-  skipped: Scalars['Int'];
-  suites: Scalars['Int'];
-  tests: Scalars['Int'];
-  wallClockDuration: Scalars['Int'];
-  wallClockEndedAt: Scalars['String'];
-  wallClockStartedAt: Scalars['String'];
-};
-
-export type InstanceTest = {
-  __typename?: 'InstanceTest';
-  attempts: Array<TestAttempt>;
-  body: Maybe<Scalars['String']>;
-  displayError: Maybe<Scalars['String']>;
-  state: TestState;
-  testId: Scalars['String'];
-  title: Array<Scalars['String']>;
+  DateTime: string;
 };
 
 export type Mutation = {
@@ -237,195 +46,334 @@ export type Mutation = {
   updateTeamsHook: TeamsHook;
 };
 
-
 export type MutationCreateBitbucketHookArgs = {
   input: CreateBitbucketHookInput;
 };
-
 
 export type MutationCreateGenericHookArgs = {
   input: CreateGenericHookInput;
 };
 
-
 export type MutationCreateGithubHookArgs = {
   input: CreateGithubHookInput;
 };
-
 
 export type MutationCreateProjectArgs = {
   project: CreateProjectInput;
 };
 
-
 export type MutationCreateSlackHookArgs = {
   input: CreateSlackHookInput;
 };
-
 
 export type MutationCreateTeamsHookArgs = {
   input: CreateTeamsHookInput;
 };
 
-
 export type MutationDeleteHookArgs = {
   input: DeleteHookInput;
 };
-
 
 export type MutationDeleteProjectArgs = {
   projectId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunArgs = {
   runId: Scalars['ID'];
 };
 
-
 export type MutationDeleteRunsArgs = {
-  runIds: Array<InputMaybe<Scalars['ID']>>;
+  runIds: Array<Maybe<Scalars['ID']>>;
 };
-
 
 export type MutationDeleteRunsInDateRangeArgs = {
-  endDate: Scalars['DateTime'];
   startDate: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
 };
-
 
 export type MutationResetInstanceArgs = {
   instanceId: Scalars['ID'];
 };
 
-
 export type MutationUpdateBitbucketHookArgs = {
   input: UpdateBitbucketHookInput;
 };
-
 
 export type MutationUpdateGenericHookArgs = {
   input: UpdateGenericHookInput;
 };
 
-
 export type MutationUpdateGithubHookArgs = {
   input: UpdateGithubHookInput;
 };
-
 
 export type MutationUpdateProjectArgs = {
   input: UpdateProjectInput;
 };
 
-
 export type MutationUpdateSlackHookArgs = {
   input: UpdateSlackHookInput;
 };
-
 
 export type MutationUpdateTeamsHookArgs = {
   input: UpdateTeamsHookInput;
 };
 
-export enum OrderingOptions {
-  Asc = 'ASC',
-  Desc = 'DESC'
-}
+export type DeleteHookInput = {
+  projectId: Scalars['String'];
+  hookId: Scalars['ID'];
+};
 
-export type Project = {
-  __typename?: 'Project';
-  hooks: Array<Hook>;
-  inactivityTimeoutSeconds: Maybe<Scalars['Int']>;
-  projectColor: Maybe<Scalars['String']>;
+export type DeleteHookResponse = {
+  __typename?: 'DeleteHookResponse';
+  projectId: Scalars['String'];
+  hookId: Scalars['ID'];
+};
+
+export type SlackHook = {
+  __typename?: 'SlackHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['SlackHookType'];
+  hookEvents: Array<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['SlackResultFilter']>;
+  slackBranchFilter: Maybe<Array<Scalars['String']>>;
+};
+
+export type CreateSlackHookInput = {
+  projectId: Scalars['ID'];
+  slackResultFilter: Maybe<Scalars['SlackResultFilter']>;
+};
+
+export type UpdateSlackHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookEvents: Array<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['SlackResultFilter']>;
+  slackBranchFilter: Maybe<Array<Scalars['String']>>;
+};
+
+export type GithubHook = {
+  __typename?: 'GithubHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['GithubHookType'];
+  githubToken: Maybe<Scalars['String']>;
+  githubContext: Maybe<Scalars['String']>;
+};
+
+export type CreateGithubHookInput = {
   projectId: Scalars['ID'];
 };
 
-export type ProjectInput = {
-  hooks: InputMaybe<Array<InputMaybe<HookInput>>>;
-  inactivityTimeoutSeconds: InputMaybe<Scalars['Int']>;
-  projectColor: InputMaybe<Scalars['String']>;
-  projectId: Scalars['String'];
+export type UpdateGithubHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  githubToken: Maybe<Scalars['String']>;
+  githubContext: Maybe<Scalars['String']>;
+};
+
+export type BitbucketHook = {
+  __typename?: 'BitbucketHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['BitbucketHookType'];
+  bitbucketUsername: Maybe<Scalars['String']>;
+  bitbucketToken: Maybe<Scalars['String']>;
+  bitbucketBuildName: Maybe<Scalars['String']>;
+};
+
+export type CreateBitbucketHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateBitbucketHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Maybe<Scalars['String']>;
+  bitbucketUsername: Scalars['String'];
+  bitbucketToken: Maybe<Scalars['String']>;
+  bitbucketBuildName: Maybe<Scalars['String']>;
+};
+
+export type TeamsHook = {
+  __typename?: 'TeamsHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookType: Scalars['TeamsHookType'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type CreateTeamsHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateTeamsHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type GenericHook = {
+  __typename?: 'GenericHook';
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  headers: Maybe<Scalars['String']>;
+  hookType: Scalars['GenericHookType'];
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type CreateGenericHookInput = {
+  projectId: Scalars['ID'];
+};
+
+export type UpdateGenericHookInput = {
+  projectId: Scalars['ID'];
+  hookId: Scalars['ID'];
+  url: Scalars['String'];
+  headers: Maybe<Scalars['String']>;
+  hookEvents: Array<Scalars['String']>;
+};
+
+export type Hook = {
+  __typename?: 'Hook';
+  hookId: Maybe<Scalars['String']>;
+  url: Maybe<Scalars['String']>;
+  headers: Maybe<Scalars['String']>;
+  hookEvents: Maybe<Array<Maybe<Scalars['String']>>>;
+  hookType: Maybe<Scalars['String']>;
+  githubToken: Maybe<Scalars['String']>;
+  githubContext: Maybe<Scalars['String']>;
+  bitbucketUsername: Maybe<Scalars['String']>;
+  bitbucketToken: Maybe<Scalars['String']>;
+  bitbucketBuildName: Maybe<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['String']>;
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type HookInput = {
+  hookId: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+  headers: Maybe<Scalars['String']>;
+  hookEvents: Maybe<Array<Maybe<Scalars['String']>>>;
+  hookType: Maybe<Scalars['String']>;
+  githubToken: Maybe<Scalars['String']>;
+  githubContext: Maybe<Scalars['String']>;
+  bitbucketUsername: Maybe<Scalars['String']>;
+  bitbucketToken: Maybe<Scalars['String']>;
+  bitbucketBuildName: Maybe<Scalars['String']>;
+  slackResultFilter: Maybe<Scalars['String']>;
+  slackBranchFilter: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type Query = {
   __typename?: 'Query';
-  instance: Maybe<Instance>;
-  project: Maybe<Project>;
   projects: Array<Project>;
-  run: Maybe<Run>;
-  runFeed: RunFeed;
+  project: Maybe<Project>;
   runs: Array<Maybe<Run>>;
+  runFeed: RunFeed;
+  run: Maybe<Run>;
+  instance: Maybe<Instance>;
   specStats: Maybe<SpecStats>;
 };
 
-
-export type QueryInstanceArgs = {
-  id: Scalars['ID'];
+export type QueryProjectsArgs = {
+  orderDirection?: Maybe<OrderingOptions>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
-
 
 export type QueryProjectArgs = {
   id: Scalars['ID'];
 };
 
-
-export type QueryProjectsArgs = {
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
-  orderDirection?: InputMaybe<OrderingOptions>;
+export type QueryRunsArgs = {
+  orderDirection?: Maybe<OrderingOptions>;
+  cursor?: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
+export type QueryRunFeedArgs = {
+  cursor: Maybe<Scalars['String']>;
+  filters?: Maybe<Array<Maybe<Filters>>>;
+};
 
 export type QueryRunArgs = {
   id: Scalars['ID'];
 };
 
-
-export type QueryRunFeedArgs = {
-  cursor: InputMaybe<Scalars['String']>;
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
+export type QueryInstanceArgs = {
+  id: Scalars['ID'];
 };
-
-
-export type QueryRunsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
-  orderDirection?: InputMaybe<OrderingOptions>;
-};
-
 
 export type QuerySpecStatsArgs = {
-  filters?: InputMaybe<Array<InputMaybe<Filters>>>;
   spec: Scalars['String'];
+  filters?: Maybe<Array<Maybe<Filters>>>;
 };
 
-export type ReporterStats = {
-  __typename?: 'ReporterStats';
-  duration: Maybe<Scalars['Int']>;
-  end: Maybe<Scalars['String']>;
-  failures: Maybe<Scalars['Int']>;
-  passes: Maybe<Scalars['Int']>;
-  pending: Maybe<Scalars['Int']>;
-  start: Maybe<Scalars['String']>;
-  suites: Maybe<Scalars['Int']>;
-  tests: Maybe<Scalars['Int']>;
-};
-
-export type ResetInstanceResponse = {
-  __typename?: 'ResetInstanceResponse';
-  instanceId: Scalars['ID'];
+export type DeleteRunResponse = {
+  __typename?: 'DeleteRunResponse';
+  success: Scalars['Boolean'];
   message: Scalars['String'];
-  success: Maybe<Scalars['Boolean']>;
+  runIds: Array<Maybe<Scalars['ID']>>;
+};
+
+export type SpecStats = {
+  __typename?: 'SpecStats';
+  spec: Scalars['String'];
+  avgWallClockDuration: Scalars['Int'];
+  count: Scalars['Int'];
+};
+
+export type Project = {
+  __typename?: 'Project';
+  projectId: Scalars['ID'];
+  hooks: Array<Hook>;
+  inactivityTimeoutSeconds: Maybe<Scalars['Int']>;
+  projectColor: Maybe<Scalars['String']>;
+};
+
+export type CreateProjectInput = {
+  projectId: Scalars['ID'];
+  inactivityTimeoutSeconds: Scalars['Int'];
+  projectColor: Maybe<Scalars['String']>;
+};
+
+export type UpdateProjectInput = {
+  projectId: Scalars['ID'];
+  inactivityTimeoutSeconds: Scalars['Int'];
+  projectColor: Maybe<Scalars['String']>;
+};
+
+export type ProjectInput = {
+  projectId: Scalars['String'];
+  inactivityTimeoutSeconds: Maybe<Scalars['Int']>;
+  projectColor: Maybe<Scalars['String']>;
+  hooks: Maybe<Array<Maybe<HookInput>>>;
+};
+
+export type DeleteProjectResponse = {
+  __typename?: 'DeleteProjectResponse';
+  success: Scalars['Boolean'];
+  message: Scalars['String'];
+  projectIds: Array<Maybe<Scalars['ID']>>;
 };
 
 export type Run = {
   __typename?: 'Run';
-  completion: Maybe<RunCompletion>;
+  runId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   meta: RunMeta;
-  progress: Maybe<RunProgress>;
-  runId: Scalars['ID'];
   specs: Array<RunSpec>;
+  completion: Maybe<RunCompletion>;
+  progress: Maybe<RunProgress>;
 };
 
 export type RunCompletion = {
@@ -434,11 +382,29 @@ export type RunCompletion = {
   inactivityTimeoutMs: Maybe<Scalars['Int']>;
 };
 
-export type RunFeed = {
-  __typename?: 'RunFeed';
-  cursor: Scalars['String'];
-  hasMore: Scalars['Boolean'];
-  runs: Array<Run>;
+export type RunSpec = {
+  __typename?: 'RunSpec';
+  spec: Scalars['String'];
+  instanceId: Scalars['String'];
+  claimedAt: Maybe<Scalars['String']>;
+  completedAt: Maybe<Scalars['String']>;
+  machineId: Maybe<Scalars['String']>;
+  tests: Maybe<Scalars['Int']>;
+  groupId: Maybe<Scalars['String']>;
+  results: Maybe<RunSpecResults>;
+};
+
+export type RunSpecResults = {
+  __typename?: 'RunSpecResults';
+  error: Maybe<Scalars['String']>;
+  retries: Maybe<Scalars['Int']>;
+  stats: InstanceStats;
+};
+
+export type RunProgress = {
+  __typename?: 'RunProgress';
+  updatedAt: Maybe<Scalars['DateTime']>;
+  groups: Array<RunGroupProgress>;
 };
 
 export type RunGroupProgress = {
@@ -450,475 +416,782 @@ export type RunGroupProgress = {
 
 export type RunGroupProgressInstances = {
   __typename?: 'RunGroupProgressInstances';
+  overall: Scalars['Int'];
   claimed: Scalars['Int'];
   complete: Scalars['Int'];
-  failures: Scalars['Int'];
-  overall: Scalars['Int'];
   passes: Scalars['Int'];
+  failures: Scalars['Int'];
 };
 
 export type RunGroupProgressTests = {
   __typename?: 'RunGroupProgressTests';
-  failures: Scalars['Int'];
   overall: Scalars['Int'];
   passes: Scalars['Int'];
+  failures: Scalars['Int'];
+  skipped: Scalars['Int'];
   pending: Scalars['Int'];
   retries: Scalars['Int'];
-  skipped: Scalars['Int'];
+};
+
+export type Commit = {
+  __typename?: 'Commit';
+  sha: Maybe<Scalars['String']>;
+  branch: Maybe<Scalars['String']>;
+  authorName: Maybe<Scalars['String']>;
+  authorEmail: Maybe<Scalars['String']>;
+  message: Maybe<Scalars['String']>;
+  remoteOrigin: Maybe<Scalars['String']>;
 };
 
 export type RunMeta = {
   __typename?: 'RunMeta';
   ciBuildId: Scalars['String'];
-  commit: Maybe<Commit>;
   projectId: Scalars['String'];
+  commit: Maybe<Commit>;
 };
 
-export type RunProgress = {
-  __typename?: 'RunProgress';
-  groups: Array<RunGroupProgress>;
-  updatedAt: Maybe<Scalars['DateTime']>;
-};
-
-export type RunSpec = {
-  __typename?: 'RunSpec';
-  claimedAt: Maybe<Scalars['String']>;
-  completedAt: Maybe<Scalars['String']>;
-  groupId: Maybe<Scalars['String']>;
-  instanceId: Scalars['String'];
-  machineId: Maybe<Scalars['String']>;
-  results: Maybe<RunSpecResults>;
-  spec: Scalars['String'];
-};
-
-export type RunSpecResults = {
-  __typename?: 'RunSpecResults';
-  error: Maybe<Scalars['String']>;
-  retries: Maybe<Scalars['Int']>;
-  stats: InstanceStats;
-};
-
-export type SlackHook = {
-  __typename?: 'SlackHook';
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['SlackHookType'];
-  projectId: Scalars['ID'];
-  slackBranchFilter: Maybe<Array<Scalars['String']>>;
-  slackResultFilter: Maybe<Scalars['SlackResultFilter']>;
-  url: Scalars['String'];
-};
-
-export type SpecStats = {
-  __typename?: 'SpecStats';
-  avgWallClockDuration: Scalars['Int'];
-  count: Scalars['Int'];
-  spec: Scalars['String'];
-};
-
-export type TeamsHook = {
-  __typename?: 'TeamsHook';
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  hookType: Scalars['TeamsHookType'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
-};
-
-export type TestAttempt = {
-  __typename?: 'TestAttempt';
-  error: Maybe<TestError>;
-  state: Maybe<Scalars['String']>;
-  wallClockDuration: Maybe<Scalars['Int']>;
-  wallClockStartedAt: Maybe<Scalars['String']>;
-};
-
-export type TestError = {
-  __typename?: 'TestError';
+export type ResetInstanceResponse = {
+  __typename?: 'ResetInstanceResponse';
+  instanceId: Scalars['ID'];
   message: Scalars['String'];
-  name: Scalars['String'];
-  stack: Scalars['String'];
+  success: Maybe<Scalars['Boolean']>;
+};
+
+export type RunFeed = {
+  __typename?: 'RunFeed';
+  cursor: Scalars['String'];
+  hasMore: Scalars['Boolean'];
+  runs: Array<Run>;
+};
+
+export type Instance = {
+  __typename?: 'Instance';
+  runId: Scalars['ID'];
+  run: Run;
+  spec: Scalars['String'];
+  groupId: Scalars['String'];
+  projectId: Scalars['String'];
+  instanceId: Scalars['ID'];
+  results: Maybe<InstanceResults>;
+};
+
+export type InstanceResults = {
+  __typename?: 'InstanceResults';
+  stats: InstanceStats;
+  tests: Maybe<Array<InstanceTest>>;
+  error: Maybe<Scalars['String']>;
+  stdout: Maybe<Scalars['String']>;
+  screenshots: Array<InstanceScreeshot>;
+  cypressConfig: Maybe<CypressConfig>;
+  reporterStats: Maybe<ReporterStats>;
+  videoUrl: Maybe<Scalars['String']>;
+};
+
+export type InstanceStats = {
+  __typename?: 'InstanceStats';
+  suites: Scalars['Int'];
+  tests: Scalars['Int'];
+  passes: Scalars['Int'];
+  pending: Scalars['Int'];
+  skipped: Scalars['Int'];
+  failures: Scalars['Int'];
+  wallClockStartedAt: Scalars['String'];
+  wallClockEndedAt: Scalars['String'];
+  wallClockDuration: Scalars['Int'];
+};
+
+export type CypressConfig = {
+  __typename?: 'CypressConfig';
+  video: Scalars['Boolean'];
+  videoUploadOnPasses: Scalars['Boolean'];
+};
+
+export type InstanceScreeshot = {
+  __typename?: 'InstanceScreeshot';
+  screenshotId: Scalars['String'];
+  name: Maybe<Scalars['String']>;
+  testId: Scalars['String'];
+  takenAt: Scalars['String'];
+  height: Scalars['Int'];
+  width: Scalars['Int'];
+  screenshotURL: Maybe<Scalars['String']>;
+};
+
+export type ReporterStats = {
+  __typename?: 'ReporterStats';
+  suites: Maybe<Scalars['Int']>;
+  tests: Maybe<Scalars['Int']>;
+  passes: Maybe<Scalars['Int']>;
+  pending: Maybe<Scalars['Int']>;
+  failures: Maybe<Scalars['Int']>;
+  start: Maybe<Scalars['String']>;
+  end: Maybe<Scalars['String']>;
+  duration: Maybe<Scalars['Int']>;
 };
 
 export enum TestState {
   Failed = 'failed',
   Passed = 'passed',
   Pending = 'pending',
-  Skipped = 'skipped'
+  Skipped = 'skipped',
 }
 
-export type UpdateBitbucketHookInput = {
-  bitbucketBuildName: InputMaybe<Scalars['String']>;
-  bitbucketToken: InputMaybe<Scalars['String']>;
-  bitbucketUsername: Scalars['String'];
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: InputMaybe<Scalars['String']>;
+export type InstanceTest = {
+  __typename?: 'InstanceTest';
+  testId: Scalars['String'];
+  title: Array<Scalars['String']>;
+  state: TestState;
+  body: Maybe<Scalars['String']>;
+  displayError: Maybe<Scalars['String']>;
+  attempts: Array<TestAttempt>;
 };
 
-export type UpdateGenericHookInput = {
-  headers: InputMaybe<Scalars['String']>;
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
+export type TestError = {
+  __typename?: 'TestError';
+  name: Scalars['String'];
+  message: Scalars['String'];
+  stack: Scalars['String'];
 };
 
-export type UpdateGithubHookInput = {
-  githubContext: InputMaybe<Scalars['String']>;
-  githubToken: InputMaybe<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
+export type TestAttempt = {
+  __typename?: 'TestAttempt';
+  state: Maybe<Scalars['String']>;
+  error: Maybe<TestError>;
+  wallClockStartedAt: Maybe<Scalars['String']>;
+  wallClockDuration: Maybe<Scalars['Int']>;
 };
 
-export type UpdateProjectInput = {
-  inactivityTimeoutSeconds: Scalars['Int'];
-  projectColor: InputMaybe<Scalars['String']>;
-  projectId: Scalars['ID'];
-};
+export enum OrderingOptions {
+  Desc = 'DESC',
+  Asc = 'ASC',
+}
 
-export type UpdateSlackHookInput = {
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  slackBranchFilter: InputMaybe<Array<Scalars['String']>>;
-  slackResultFilter: InputMaybe<Scalars['SlackResultFilter']>;
-  url: Scalars['String'];
-};
-
-export type UpdateTeamsHookInput = {
-  hookEvents: Array<Scalars['String']>;
-  hookId: Scalars['ID'];
-  projectId: Scalars['ID'];
-  url: Scalars['String'];
+export type Filters = {
+  key: Maybe<Scalars['String']>;
+  value: Maybe<Scalars['String']>;
+  like: Maybe<Scalars['String']>;
 };
 
 export type GetInstanceQueryVariables = Exact<{
   instanceId: Scalars['ID'];
 }>;
 
+export type GetInstanceQuery = {
+  __typename?: 'Query';
+  instance: Maybe<{
+    __typename?: 'Instance';
+    instanceId: string;
+    runId: string;
+    spec: string;
+    projectId: string;
+    run: {
+      __typename?: 'Run';
+      runId: string;
+      meta: { __typename?: 'RunMeta'; ciBuildId: string };
+    };
+    results: Maybe<{
+      __typename?: 'InstanceResults';
+      error: Maybe<string>;
+      videoUrl: Maybe<string>;
+      stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+      tests: Maybe<
+        Array<{ __typename?: 'InstanceTest' } & GetInstanceTestFragment>
+      >;
+      screenshots: Array<{
+        __typename?: 'InstanceScreeshot';
+        testId: string;
+        screenshotId: string;
+        height: number;
+        width: number;
+        screenshotURL: Maybe<string>;
+      }>;
+      cypressConfig: Maybe<{
+        __typename?: 'CypressConfig';
+        video: boolean;
+        videoUploadOnPasses: boolean;
+      }>;
+    }>;
+  }>;
+};
 
-export type GetInstanceQuery = { __typename?: 'Query', instance: { __typename?: 'Instance', instanceId: string, runId: string, spec: string, projectId: string, run: { __typename?: 'Run', runId: string, meta: { __typename?: 'RunMeta', ciBuildId: string } }, results: { __typename?: 'InstanceResults', error: string | null, videoUrl: string | null, stats: { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string }, tests: Array<{ __typename?: 'InstanceTest', testId: string, title: Array<string>, state: TestState, body: string | null, displayError: string | null, attempts: Array<{ __typename?: 'TestAttempt', state: string | null, wallClockDuration: number | null, wallClockStartedAt: string | null, error: { __typename?: 'TestError', name: string, message: string, stack: string } | null }> }> | null, screenshots: Array<{ __typename?: 'InstanceScreeshot', testId: string, screenshotId: string, height: number, width: number, screenshotURL: string | null }>, cypressConfig: { __typename?: 'CypressConfig', video: boolean, videoUploadOnPasses: boolean } | null } | null } | null };
-
-export type GetInstanceTestFragment = { __typename?: 'InstanceTest', testId: string, title: Array<string>, state: TestState, body: string | null, displayError: string | null, attempts: Array<{ __typename?: 'TestAttempt', state: string | null, wallClockDuration: number | null, wallClockStartedAt: string | null, error: { __typename?: 'TestError', name: string, message: string, stack: string } | null }> };
+export type GetInstanceTestFragment = {
+  __typename?: 'InstanceTest';
+  testId: string;
+  title: Array<string>;
+  state: TestState;
+  body: Maybe<string>;
+  displayError: Maybe<string>;
+  attempts: Array<{
+    __typename?: 'TestAttempt';
+    state: Maybe<string>;
+    wallClockDuration: Maybe<number>;
+    wallClockStartedAt: Maybe<string>;
+    error: Maybe<{
+      __typename?: 'TestError';
+      name: string;
+      message: string;
+      stack: string;
+    }>;
+  }>;
+};
 
 export type CreateProjectMutationVariables = Exact<{
   project: CreateProjectInput;
 }>;
 
-
-export type CreateProjectMutation = { __typename?: 'Mutation', createProject: { __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: number | null, projectColor: string | null } };
+export type CreateProjectMutation = {
+  __typename?: 'Mutation';
+  createProject: {
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+    projectColor: Maybe<string>;
+  };
+};
 
 export type DeleteProjectMutationVariables = Exact<{
   projectId: Scalars['ID'];
 }>;
 
-
-export type DeleteProjectMutation = { __typename?: 'Mutation', deleteProject: { __typename?: 'DeleteProjectResponse', success: boolean, message: string, projectIds: Array<string | null> } };
+export type DeleteProjectMutation = {
+  __typename?: 'Mutation';
+  deleteProject: {
+    __typename?: 'DeleteProjectResponse';
+    success: boolean;
+    message: string;
+    projectIds: Array<Maybe<string>>;
+  };
+};
 
 export type GetProjectQueryVariables = Exact<{
   projectId: Scalars['ID'];
 }>;
 
-
-export type GetProjectQuery = { __typename?: 'Query', project: { __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: number | null, projectColor: string | null, hooks: Array<{ __typename?: 'Hook', hookId: string | null, url: string | null, headers: string | null, hookEvents: Array<string | null> | null, hookType: string | null, slackResultFilter: string | null, slackBranchFilter: Array<string | null> | null, githubContext: string | null, githubToken: string | null, bitbucketUsername: string | null, bitbucketToken: string | null, bitbucketBuildName: string | null }> } | null };
+export type GetProjectQuery = {
+  __typename?: 'Query';
+  project: Maybe<{
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+    projectColor: Maybe<string>;
+    hooks: Array<{
+      __typename?: 'Hook';
+      hookId: Maybe<string>;
+      url: Maybe<string>;
+      headers: Maybe<string>;
+      hookEvents: Maybe<Array<Maybe<string>>>;
+      hookType: Maybe<string>;
+      slackResultFilter: Maybe<string>;
+      slackBranchFilter: Maybe<Array<Maybe<string>>>;
+      githubContext: Maybe<string>;
+      githubToken: Maybe<string>;
+      bitbucketUsername: Maybe<string>;
+      bitbucketToken: Maybe<string>;
+      bitbucketBuildName: Maybe<string>;
+    }>;
+  }>;
+};
 
 export type GetProjectsQueryVariables = Exact<{
-  orderDirection: InputMaybe<OrderingOptions>;
+  orderDirection: Maybe<OrderingOptions>;
   filters: Array<Filters> | Filters;
 }>;
 
-
-export type GetProjectsQuery = { __typename?: 'Query', projects: Array<{ __typename?: 'Project', projectId: string, projectColor: string | null }> };
+export type GetProjectsQuery = {
+  __typename?: 'Query';
+  projects: Array<{
+    __typename?: 'Project';
+    projectId: string;
+    projectColor: Maybe<string>;
+  }>;
+};
 
 export type CreateBitbucketHookMutationVariables = Exact<{
   input: CreateBitbucketHookInput;
 }>;
 
-
-export type CreateBitbucketHookMutation = { __typename?: 'Mutation', createBitbucketHook: { __typename?: 'BitbucketHook', projectId: string, hookId: string, hookType: any, url: string, bitbucketUsername: string | null, bitbucketBuildName: string | null } };
+export type CreateBitbucketHookMutation = {
+  __typename?: 'Mutation';
+  createBitbucketHook: {
+    __typename?: 'BitbucketHook';
+    projectId: string;
+    hookId: string;
+    hookType: any;
+    url: string;
+    bitbucketUsername: Maybe<string>;
+    bitbucketBuildName: Maybe<string>;
+  };
+};
 
 export type CreateGenericHookMutationVariables = Exact<{
   input: CreateGenericHookInput;
 }>;
 
-
-export type CreateGenericHookMutation = { __typename?: 'Mutation', createGenericHook: { __typename?: 'GenericHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, headers: string | null } };
+export type CreateGenericHookMutation = {
+  __typename?: 'Mutation';
+  createGenericHook: {
+    __typename?: 'GenericHook';
+    hookId: string;
+    hookType: any;
+    url: string;
+    hookEvents: Array<string>;
+    headers: Maybe<string>;
+  };
+};
 
 export type CreateGithubHookMutationVariables = Exact<{
   input: CreateGithubHookInput;
 }>;
 
-
-export type CreateGithubHookMutation = { __typename?: 'Mutation', createGithubHook: { __typename?: 'GithubHook', projectId: string, hookId: string, hookType: any, url: string, githubToken: string | null, githubContext: string | null } };
+export type CreateGithubHookMutation = {
+  __typename?: 'Mutation';
+  createGithubHook: {
+    __typename?: 'GithubHook';
+    projectId: string;
+    hookId: string;
+    hookType: any;
+    url: string;
+    githubToken: Maybe<string>;
+    githubContext: Maybe<string>;
+  };
+};
 
 export type CreateSlackHookMutationVariables = Exact<{
   input: CreateSlackHookInput;
 }>;
 
-
-export type CreateSlackHookMutation = { __typename?: 'Mutation', createSlackHook: { __typename?: 'SlackHook', hookId: string, hookType: any, url: string, hookEvents: Array<string>, slackResultFilter: any | null, slackBranchFilter: Array<string> | null } };
+export type CreateSlackHookMutation = {
+  __typename?: 'Mutation';
+  createSlackHook: {
+    __typename?: 'SlackHook';
+    hookId: string;
+    hookType: any;
+    url: string;
+    hookEvents: Array<string>;
+    slackResultFilter: Maybe<any>;
+    slackBranchFilter: Maybe<Array<string>>;
+  };
+};
 
 export type CreateTeamsHookMutationVariables = Exact<{
   input: CreateTeamsHookInput;
 }>;
 
-
-export type CreateTeamsHookMutation = { __typename?: 'Mutation', createTeamsHook: { __typename?: 'TeamsHook', hookId: string, hookType: any, url: string, hookEvents: Array<string> } };
+export type CreateTeamsHookMutation = {
+  __typename?: 'Mutation';
+  createTeamsHook: {
+    __typename?: 'TeamsHook';
+    hookId: string;
+    hookType: any;
+    url: string;
+    hookEvents: Array<string>;
+  };
+};
 
 export type DeleteHookMutationVariables = Exact<{
   input: DeleteHookInput;
 }>;
 
-
-export type DeleteHookMutation = { __typename?: 'Mutation', deleteHook: { __typename?: 'DeleteHookResponse', hookId: string, projectId: string } };
+export type DeleteHookMutation = {
+  __typename?: 'Mutation';
+  deleteHook: {
+    __typename?: 'DeleteHookResponse';
+    hookId: string;
+    projectId: string;
+  };
+};
 
 export type UpdateBitbucketHookMutationVariables = Exact<{
   input: UpdateBitbucketHookInput;
 }>;
 
-
-export type UpdateBitbucketHookMutation = { __typename?: 'Mutation', updateBitbucketHook: { __typename?: 'BitbucketHook', hookId: string } };
+export type UpdateBitbucketHookMutation = {
+  __typename?: 'Mutation';
+  updateBitbucketHook: { __typename?: 'BitbucketHook'; hookId: string };
+};
 
 export type UpdateGenericHookMutationVariables = Exact<{
   input: UpdateGenericHookInput;
 }>;
 
-
-export type UpdateGenericHookMutation = { __typename?: 'Mutation', updateGenericHook: { __typename?: 'GenericHook', hookId: string } };
+export type UpdateGenericHookMutation = {
+  __typename?: 'Mutation';
+  updateGenericHook: { __typename?: 'GenericHook'; hookId: string };
+};
 
 export type UpdateGithubHookMutationVariables = Exact<{
   input: UpdateGithubHookInput;
 }>;
 
-
-export type UpdateGithubHookMutation = { __typename?: 'Mutation', updateGithubHook: { __typename?: 'GithubHook', hookId: string } };
+export type UpdateGithubHookMutation = {
+  __typename?: 'Mutation';
+  updateGithubHook: { __typename?: 'GithubHook'; hookId: string };
+};
 
 export type UpdateSlackHookMutationVariables = Exact<{
   input: UpdateSlackHookInput;
 }>;
 
-
-export type UpdateSlackHookMutation = { __typename?: 'Mutation', updateSlackHook: { __typename?: 'SlackHook', hookId: string } };
+export type UpdateSlackHookMutation = {
+  __typename?: 'Mutation';
+  updateSlackHook: { __typename?: 'SlackHook'; hookId: string };
+};
 
 export type UpdateTeamsHookMutationVariables = Exact<{
   input: UpdateTeamsHookInput;
 }>;
 
-
-export type UpdateTeamsHookMutation = { __typename?: 'Mutation', updateTeamsHook: { __typename?: 'TeamsHook', hookId: string } };
+export type UpdateTeamsHookMutation = {
+  __typename?: 'Mutation';
+  updateTeamsHook: { __typename?: 'TeamsHook'; hookId: string };
+};
 
 export type UpdateProjectMutationVariables = Exact<{
   input: UpdateProjectInput;
 }>;
 
-
-export type UpdateProjectMutation = { __typename?: 'Mutation', updateProject: { __typename?: 'Project', projectId: string, inactivityTimeoutSeconds: number | null, projectColor: string | null } };
+export type UpdateProjectMutation = {
+  __typename?: 'Mutation';
+  updateProject: {
+    __typename?: 'Project';
+    projectId: string;
+    inactivityTimeoutSeconds: Maybe<number>;
+    projectColor: Maybe<string>;
+  };
+};
 
 export type DeleteRunMutationVariables = Exact<{
   runId: Scalars['ID'];
 }>;
 
-
-export type DeleteRunMutation = { __typename?: 'Mutation', deleteRun: { __typename?: 'DeleteRunResponse', success: boolean, message: string, runIds: Array<string | null> } };
+export type DeleteRunMutation = {
+  __typename?: 'Mutation';
+  deleteRun: {
+    __typename?: 'DeleteRunResponse';
+    success: boolean;
+    message: string;
+    runIds: Array<Maybe<string>>;
+  };
+};
 
 export type GetSpecStatsQueryVariables = Exact<{
   spec: Scalars['String'];
 }>;
 
-
-export type GetSpecStatsQuery = { __typename?: 'Query', specStats: { __typename?: 'SpecStats', spec: string, count: number, avgWallClockDuration: number } | null };
+export type GetSpecStatsQuery = {
+  __typename?: 'Query';
+  specStats: Maybe<{
+    __typename?: 'SpecStats';
+    spec: string;
+    count: number;
+    avgWallClockDuration: number;
+  }>;
+};
 
 export type GetRunQueryVariables = Exact<{
   runId: Scalars['ID'];
 }>;
 
-
-export type GetRunQuery = { __typename?: 'Query', run: { __typename?: 'Run', runId: string, createdAt: string, completion: { __typename?: 'RunCompletion', completed: boolean, inactivityTimeoutMs: number | null } | null, meta: { __typename?: 'RunMeta', ciBuildId: string, projectId: string, commit: { __typename?: 'Commit', sha: string | null, branch: string | null, remoteOrigin: string | null, message: string | null, authorEmail: string | null, authorName: string | null } | null }, specs: Array<{ __typename?: 'RunSpec', instanceId: string, spec: string, claimedAt: string | null, machineId: string | null, groupId: string | null, results: { __typename?: 'RunSpecResults', error: string | null, retries: number | null, stats: { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string } } | null }>, progress: { __typename?: 'RunProgress', updatedAt: string | null, groups: Array<{ __typename?: 'RunGroupProgress', groupId: string, instances: { __typename?: 'RunGroupProgressInstances', overall: number, claimed: number, complete: number, failures: number, passes: number }, tests: { __typename?: 'RunGroupProgressTests', overall: number, passes: number, failures: number, pending: number, skipped: number, retries: number } }> } | null } | null };
+export type GetRunQuery = {
+  __typename?: 'Query';
+  run: Maybe<{
+    __typename?: 'Run';
+    runId: string;
+    createdAt: string;
+    completion: Maybe<
+      { __typename?: 'RunCompletion' } & RunSummaryCompletionFragment
+    >;
+    meta: { __typename?: 'RunMeta' } & RunSummaryMetaFragment;
+    specs: Array<{ __typename?: 'RunSpec' } & RunDetailSpecFragment>;
+    progress: Maybe<{ __typename?: 'RunProgress' } & RunProgressFragment>;
+  }>;
+};
 
 export type ResetInstanceMutationVariables = Exact<{
   instanceId: Scalars['ID'];
 }>;
 
+export type ResetInstanceMutation = {
+  __typename?: 'Mutation';
+  resetInstance: {
+    __typename?: 'ResetInstanceResponse';
+    success: Maybe<boolean>;
+    message: string;
+    instanceId: string;
+  };
+};
 
-export type ResetInstanceMutation = { __typename?: 'Mutation', resetInstance: { __typename?: 'ResetInstanceResponse', success: boolean | null, message: string, instanceId: string } };
+export type RunDetailSpecFragment = {
+  __typename?: 'RunSpec';
+  instanceId: string;
+  spec: string;
+  claimedAt: Maybe<string>;
+  machineId: Maybe<string>;
+  groupId: Maybe<string>;
+  results: Maybe<{
+    __typename?: 'RunSpecResults';
+    error: Maybe<string>;
+    retries: Maybe<number>;
+    stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+  }>;
+};
 
-export type RunDetailSpecFragment = { __typename?: 'RunSpec', instanceId: string, spec: string, claimedAt: string | null, machineId: string | null, groupId: string | null, results: { __typename?: 'RunSpecResults', error: string | null, retries: number | null, stats: { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string } } | null };
+export type AllInstanceStatsFragment = {
+  __typename?: 'InstanceStats';
+  suites: number;
+  tests: number;
+  pending: number;
+  passes: number;
+  failures: number;
+  skipped: number;
+  wallClockDuration: number;
+  wallClockStartedAt: string;
+  wallClockEndedAt: string;
+};
 
-export type AllInstanceStatsFragment = { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string };
+export type RunSummaryCompletionFragment = {
+  __typename?: 'RunCompletion';
+  completed: boolean;
+  inactivityTimeoutMs: Maybe<number>;
+};
 
-export type RunSummaryCompletionFragment = { __typename?: 'RunCompletion', completed: boolean, inactivityTimeoutMs: number | null };
+export type RunSummaryMetaFragment = {
+  __typename?: 'RunMeta';
+  ciBuildId: string;
+  projectId: string;
+  commit: Maybe<{
+    __typename?: 'Commit';
+    sha: Maybe<string>;
+    branch: Maybe<string>;
+    remoteOrigin: Maybe<string>;
+    message: Maybe<string>;
+    authorEmail: Maybe<string>;
+    authorName: Maybe<string>;
+  }>;
+};
 
-export type RunSummaryMetaFragment = { __typename?: 'RunMeta', ciBuildId: string, projectId: string, commit: { __typename?: 'Commit', sha: string | null, branch: string | null, remoteOrigin: string | null, message: string | null, authorEmail: string | null, authorName: string | null } | null };
-
-export type RunSummarySpecFragment = { __typename?: 'RunSpec', claimedAt: string | null, results: { __typename?: 'RunSpecResults', stats: { __typename?: 'InstanceStats', suites: number, tests: number, pending: number, passes: number, failures: number, skipped: number, wallClockDuration: number, wallClockStartedAt: string, wallClockEndedAt: string } } | null };
+export type RunSummarySpecFragment = {
+  __typename?: 'RunSpec';
+  claimedAt: Maybe<string>;
+  results: Maybe<{
+    __typename?: 'RunSpecResults';
+    stats: { __typename?: 'InstanceStats' } & AllInstanceStatsFragment;
+  }>;
+};
 
 export type GetRunsFeedQueryVariables = Exact<{
-  cursor: InputMaybe<Scalars['String']>;
+  cursor: Maybe<Scalars['String']>;
   filters: Array<Filters> | Filters;
 }>;
 
+export type GetRunsFeedQuery = {
+  __typename?: 'Query';
+  runFeed: {
+    __typename?: 'RunFeed';
+    cursor: string;
+    hasMore: boolean;
+    runs: Array<{
+      __typename?: 'Run';
+      runId: string;
+      createdAt: string;
+      completion: Maybe<
+        { __typename?: 'RunCompletion' } & RunSummaryCompletionFragment
+      >;
+      meta: { __typename?: 'RunMeta' } & RunSummaryMetaFragment;
+      progress: Maybe<{ __typename?: 'RunProgress' } & RunProgressFragment>;
+    }>;
+  };
+};
 
-export type GetRunsFeedQuery = { __typename?: 'Query', runFeed: { __typename?: 'RunFeed', cursor: string, hasMore: boolean, runs: Array<{ __typename?: 'Run', runId: string, createdAt: string, completion: { __typename?: 'RunCompletion', completed: boolean, inactivityTimeoutMs: number | null } | null, meta: { __typename?: 'RunMeta', ciBuildId: string, projectId: string, commit: { __typename?: 'Commit', sha: string | null, branch: string | null, remoteOrigin: string | null, message: string | null, authorEmail: string | null, authorName: string | null } | null }, progress: { __typename?: 'RunProgress', updatedAt: string | null, groups: Array<{ __typename?: 'RunGroupProgress', groupId: string, instances: { __typename?: 'RunGroupProgressInstances', overall: number, claimed: number, complete: number, failures: number, passes: number }, tests: { __typename?: 'RunGroupProgressTests', overall: number, passes: number, failures: number, pending: number, skipped: number, retries: number } }> } | null }> } };
+export type RunProgressFragment = {
+  __typename?: 'RunProgress';
+  updatedAt: Maybe<string>;
+  groups: Array<{
+    __typename?: 'RunGroupProgress';
+    groupId: string;
+    instances: {
+      __typename?: 'RunGroupProgressInstances';
+    } & RunGroupProgressInstancesFragment;
+    tests: {
+      __typename?: 'RunGroupProgressTests';
+    } & RunGroupProgressTestsFragment;
+  }>;
+};
 
-export type RunProgressFragment = { __typename?: 'RunProgress', updatedAt: string | null, groups: Array<{ __typename?: 'RunGroupProgress', groupId: string, instances: { __typename?: 'RunGroupProgressInstances', overall: number, claimed: number, complete: number, failures: number, passes: number }, tests: { __typename?: 'RunGroupProgressTests', overall: number, passes: number, failures: number, pending: number, skipped: number, retries: number } }> };
+export type RunGroupProgressInstancesFragment = {
+  __typename?: 'RunGroupProgressInstances';
+  overall: number;
+  claimed: number;
+  complete: number;
+  failures: number;
+  passes: number;
+};
 
-export type RunGroupProgressInstancesFragment = { __typename?: 'RunGroupProgressInstances', overall: number, claimed: number, complete: number, failures: number, passes: number };
-
-export type RunGroupProgressTestsFragment = { __typename?: 'RunGroupProgressTests', overall: number, passes: number, failures: number, pending: number, skipped: number, retries: number };
+export type RunGroupProgressTestsFragment = {
+  __typename?: 'RunGroupProgressTests';
+  overall: number;
+  passes: number;
+  failures: number;
+  pending: number;
+  skipped: number;
+  retries: number;
+};
 
 export const GetInstanceTestFragmentDoc = gql`
-    fragment GetInstanceTest on InstanceTest {
-  testId
-  title
-  state
-  body
-  displayError
-  attempts {
+  fragment GetInstanceTest on InstanceTest {
+    testId
+    title
     state
-    wallClockDuration
-    wallClockStartedAt
-    error {
-      name
-      message
-      stack
-    }
-  }
-}
-    `;
-export const AllInstanceStatsFragmentDoc = gql`
-    fragment AllInstanceStats on InstanceStats {
-  suites
-  tests
-  pending
-  passes
-  failures
-  skipped
-  suites
-  wallClockDuration
-  wallClockStartedAt
-  wallClockEndedAt
-}
-    `;
-export const RunDetailSpecFragmentDoc = gql`
-    fragment RunDetailSpec on RunSpec {
-  instanceId
-  spec
-  claimedAt
-  machineId
-  groupId
-  results {
-    error
-    retries
-    stats {
-      ...AllInstanceStats
-    }
-  }
-}
-    ${AllInstanceStatsFragmentDoc}`;
-export const RunSummaryCompletionFragmentDoc = gql`
-    fragment RunSummaryCompletion on RunCompletion {
-  completed
-  inactivityTimeoutMs
-}
-    `;
-export const RunSummaryMetaFragmentDoc = gql`
-    fragment RunSummaryMeta on RunMeta {
-  ciBuildId
-  projectId
-  commit {
-    sha
-    branch
-    remoteOrigin
-    message
-    authorEmail
-    authorName
-  }
-}
-    `;
-export const RunSummarySpecFragmentDoc = gql`
-    fragment RunSummarySpec on RunSpec {
-  claimedAt
-  results {
-    stats {
-      ...AllInstanceStats
-    }
-  }
-}
-    ${AllInstanceStatsFragmentDoc}`;
-export const RunGroupProgressInstancesFragmentDoc = gql`
-    fragment RunGroupProgressInstances on RunGroupProgressInstances {
-  overall
-  claimed
-  complete
-  failures
-  passes
-}
-    `;
-export const RunGroupProgressTestsFragmentDoc = gql`
-    fragment RunGroupProgressTests on RunGroupProgressTests {
-  overall
-  passes
-  failures
-  pending
-  skipped
-  retries
-}
-    `;
-export const RunProgressFragmentDoc = gql`
-    fragment RunProgress on RunProgress {
-  updatedAt
-  groups {
-    groupId
-    instances {
-      ...RunGroupProgressInstances
-    }
-    tests {
-      ...RunGroupProgressTests
-    }
-  }
-}
-    ${RunGroupProgressInstancesFragmentDoc}
-${RunGroupProgressTestsFragmentDoc}`;
-export const GetInstanceDocument = gql`
-    query getInstance($instanceId: ID!) {
-  instance(id: $instanceId) {
-    instanceId
-    runId
-    spec
-    projectId
-    run {
-      runId
-      meta {
-        ciBuildId
+    body
+    displayError
+    attempts {
+      state
+      wallClockDuration
+      wallClockStartedAt
+      error {
+        name
+        message
+        stack
       }
     }
+  }
+`;
+export const AllInstanceStatsFragmentDoc = gql`
+  fragment AllInstanceStats on InstanceStats {
+    suites
+    tests
+    pending
+    passes
+    failures
+    skipped
+    suites
+    wallClockDuration
+    wallClockStartedAt
+    wallClockEndedAt
+  }
+`;
+export const RunDetailSpecFragmentDoc = gql`
+  fragment RunDetailSpec on RunSpec {
+    instanceId
+    spec
+    claimedAt
+    machineId
+    groupId
     results {
       error
+      retries
       stats {
         ...AllInstanceStats
       }
-      tests {
-        ...GetInstanceTest
-      }
-      screenshots {
-        testId
-        screenshotId
-        height
-        width
-        screenshotURL
-      }
-      cypressConfig {
-        video
-        videoUploadOnPasses
-      }
-      videoUrl
     }
   }
-}
-    ${AllInstanceStatsFragmentDoc}
-${GetInstanceTestFragmentDoc}`;
+  ${AllInstanceStatsFragmentDoc}
+`;
+export const RunSummaryCompletionFragmentDoc = gql`
+  fragment RunSummaryCompletion on RunCompletion {
+    completed
+    inactivityTimeoutMs
+  }
+`;
+export const RunSummaryMetaFragmentDoc = gql`
+  fragment RunSummaryMeta on RunMeta {
+    ciBuildId
+    projectId
+    commit {
+      sha
+      branch
+      remoteOrigin
+      message
+      authorEmail
+      authorName
+    }
+  }
+`;
+export const RunSummarySpecFragmentDoc = gql`
+  fragment RunSummarySpec on RunSpec {
+    claimedAt
+    results {
+      stats {
+        ...AllInstanceStats
+      }
+    }
+  }
+  ${AllInstanceStatsFragmentDoc}
+`;
+export const RunGroupProgressInstancesFragmentDoc = gql`
+  fragment RunGroupProgressInstances on RunGroupProgressInstances {
+    overall
+    claimed
+    complete
+    failures
+    passes
+  }
+`;
+export const RunGroupProgressTestsFragmentDoc = gql`
+  fragment RunGroupProgressTests on RunGroupProgressTests {
+    overall
+    passes
+    failures
+    pending
+    skipped
+    retries
+  }
+`;
+export const RunProgressFragmentDoc = gql`
+  fragment RunProgress on RunProgress {
+    updatedAt
+    groups {
+      groupId
+      instances {
+        ...RunGroupProgressInstances
+      }
+      tests {
+        ...RunGroupProgressTests
+      }
+    }
+  }
+  ${RunGroupProgressInstancesFragmentDoc}
+  ${RunGroupProgressTestsFragmentDoc}
+`;
+export const GetInstanceDocument = gql`
+  query getInstance($instanceId: ID!) {
+    instance(id: $instanceId) {
+      instanceId
+      runId
+      spec
+      projectId
+      run {
+        runId
+        meta {
+          ciBuildId
+        }
+      }
+      results {
+        error
+        stats {
+          ...AllInstanceStats
+        }
+        tests {
+          ...GetInstanceTest
+        }
+        screenshots {
+          testId
+          screenshotId
+          height
+          width
+          screenshotURL
+        }
+        cypressConfig {
+          video
+          videoUploadOnPasses
+        }
+        videoUrl
+      }
+    }
+  }
+  ${AllInstanceStatsFragmentDoc}
+  ${GetInstanceTestFragmentDoc}
+`;
 
 /**
  * __useGetInstanceQuery__
@@ -936,27 +1209,49 @@ ${GetInstanceTestFragmentDoc}`;
  *   },
  * });
  */
-export function useGetInstanceQuery(baseOptions: Apollo.QueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, options);
-      }
-export function useGetInstanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetInstanceQuery, GetInstanceQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(GetInstanceDocument, options);
-        }
-export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
-export type GetInstanceLazyQueryHookResult = ReturnType<typeof useGetInstanceLazyQuery>;
-export type GetInstanceQueryResult = Apollo.QueryResult<GetInstanceQuery, GetInstanceQueryVariables>;
-export const CreateProjectDocument = gql`
-    mutation createProject($project: CreateProjectInput!) {
-  createProject(project: $project) {
-    projectId
-    inactivityTimeoutSeconds
-    projectColor
-  }
+export function useGetInstanceQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetInstanceQuery, GetInstanceQueryVariables>(
+    GetInstanceDocument,
+    baseOptions
+  );
 }
-    `;
-export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+export function useGetInstanceLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetInstanceQuery,
+    GetInstanceQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetInstanceQuery, GetInstanceQueryVariables>(
+    GetInstanceDocument,
+    baseOptions
+  );
+}
+export type GetInstanceQueryHookResult = ReturnType<typeof useGetInstanceQuery>;
+export type GetInstanceLazyQueryHookResult = ReturnType<
+  typeof useGetInstanceLazyQuery
+>;
+export type GetInstanceQueryResult = Apollo.QueryResult<
+  GetInstanceQuery,
+  GetInstanceQueryVariables
+>;
+export const CreateProjectDocument = gql`
+  mutation createProject($project: CreateProjectInput!) {
+    createProject(project: $project) {
+      projectId
+      inactivityTimeoutSeconds
+      projectColor
+    }
+  }
+`;
+export type CreateProjectMutationFn = Apollo.MutationFunction<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;
 
 /**
  * __useCreateProjectMutation__
@@ -975,23 +1270,40 @@ export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutat
  *   },
  * });
  */
-export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
-      }
-export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
-export const DeleteProjectDocument = gql`
-    mutation deleteProject($projectId: ID!) {
-  deleteProject(projectId: $projectId) {
-    success
-    message
-    projectIds
-  }
+export function useCreateProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >(CreateProjectDocument, baseOptions);
 }
-    `;
-export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type CreateProjectMutationHookResult = ReturnType<
+  typeof useCreateProjectMutation
+>;
+export type CreateProjectMutationResult = Apollo.MutationResult<
+  CreateProjectMutation
+>;
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;
+export const DeleteProjectDocument = gql`
+  mutation deleteProject($projectId: ID!) {
+    deleteProject(projectId: $projectId) {
+      success
+      message
+      projectIds
+    }
+  }
+`;
+export type DeleteProjectMutationFn = Apollo.MutationFunction<
+  DeleteProjectMutation,
+  DeleteProjectMutationVariables
+>;
 
 /**
  * __useDeleteProjectMutation__
@@ -1010,36 +1322,50 @@ export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutat
  *   },
  * });
  */
-export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, options);
-      }
-export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
-export type DeleteProjectMutationResult = Apollo.MutationResult<DeleteProjectMutation>;
-export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export function useDeleteProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteProjectMutation,
+    DeleteProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    DeleteProjectMutation,
+    DeleteProjectMutationVariables
+  >(DeleteProjectDocument, baseOptions);
+}
+export type DeleteProjectMutationHookResult = ReturnType<
+  typeof useDeleteProjectMutation
+>;
+export type DeleteProjectMutationResult = Apollo.MutationResult<
+  DeleteProjectMutation
+>;
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<
+  DeleteProjectMutation,
+  DeleteProjectMutationVariables
+>;
 export const GetProjectDocument = gql`
-    query getProject($projectId: ID!) {
-  project(id: $projectId) {
-    projectId
-    inactivityTimeoutSeconds
-    projectColor
-    hooks {
-      hookId
-      url
-      headers
-      hookEvents
-      hookType
-      slackResultFilter
-      slackBranchFilter
-      githubContext
-      githubToken
-      bitbucketUsername
-      bitbucketToken
-      bitbucketBuildName
+  query getProject($projectId: ID!) {
+    project(id: $projectId) {
+      projectId
+      inactivityTimeoutSeconds
+      projectColor
+      hooks {
+        hookId
+        url
+        headers
+        hookEvents
+        hookType
+        slackResultFilter
+        slackBranchFilter
+        githubContext
+        githubToken
+        bitbucketUsername
+        bitbucketToken
+        bitbucketBuildName
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetProjectQuery__
@@ -1057,25 +1383,44 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
-      }
-export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
-        }
-export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
-export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
-export type GetProjectQueryResult = Apollo.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
-export const GetProjectsDocument = gql`
-    query getProjects($orderDirection: OrderingOptions, $filters: [Filters!]!) {
-  projects(orderDirection: $orderDirection, filters: $filters) {
-    projectId
-    projectColor
-  }
+export function useGetProjectQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetProjectQuery,
+    GetProjectQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(
+    GetProjectDocument,
+    baseOptions
+  );
 }
-    `;
+export function useGetProjectLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProjectQuery,
+    GetProjectQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(
+    GetProjectDocument,
+    baseOptions
+  );
+}
+export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
+export type GetProjectLazyQueryHookResult = ReturnType<
+  typeof useGetProjectLazyQuery
+>;
+export type GetProjectQueryResult = Apollo.QueryResult<
+  GetProjectQuery,
+  GetProjectQueryVariables
+>;
+export const GetProjectsDocument = gql`
+  query getProjects($orderDirection: OrderingOptions, $filters: [Filters!]!) {
+    projects(orderDirection: $orderDirection, filters: $filters) {
+      projectId
+      projectColor
+    }
+  }
+`;
 
 /**
  * __useGetProjectsQuery__
@@ -1094,30 +1439,52 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(baseOptions: Apollo.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
-      }
-export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
-        }
-export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
-export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
-export type GetProjectsQueryResult = Apollo.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
-export const CreateBitbucketHookDocument = gql`
-    mutation createBitbucketHook($input: CreateBitbucketHookInput!) {
-  createBitbucketHook(input: $input) {
-    projectId
-    hookId
-    hookType
-    url
-    bitbucketUsername
-    bitbucketBuildName
-  }
+export function useGetProjectsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetProjectsQuery,
+    GetProjectsQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(
+    GetProjectsDocument,
+    baseOptions
+  );
 }
-    `;
-export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>;
+export function useGetProjectsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProjectsQuery,
+    GetProjectsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(
+    GetProjectsDocument,
+    baseOptions
+  );
+}
+export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
+export type GetProjectsLazyQueryHookResult = ReturnType<
+  typeof useGetProjectsLazyQuery
+>;
+export type GetProjectsQueryResult = Apollo.QueryResult<
+  GetProjectsQuery,
+  GetProjectsQueryVariables
+>;
+export const CreateBitbucketHookDocument = gql`
+  mutation createBitbucketHook($input: CreateBitbucketHookInput!) {
+    createBitbucketHook(input: $input) {
+      projectId
+      hookId
+      hookType
+      url
+      bitbucketUsername
+      bitbucketBuildName
+    }
+  }
+`;
+export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<
+  CreateBitbucketHookMutation,
+  CreateBitbucketHookMutationVariables
+>;
 
 /**
  * __useCreateBitbucketHookMutation__
@@ -1136,25 +1503,42 @@ export type CreateBitbucketHookMutationFn = Apollo.MutationFunction<CreateBitbuc
  *   },
  * });
  */
-export function useCreateBitbucketHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>(CreateBitbucketHookDocument, options);
-      }
-export type CreateBitbucketHookMutationHookResult = ReturnType<typeof useCreateBitbucketHookMutation>;
-export type CreateBitbucketHookMutationResult = Apollo.MutationResult<CreateBitbucketHookMutation>;
-export type CreateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<CreateBitbucketHookMutation, CreateBitbucketHookMutationVariables>;
-export const CreateGenericHookDocument = gql`
-    mutation createGenericHook($input: CreateGenericHookInput!) {
-  createGenericHook(input: $input) {
-    hookId
-    hookType
-    url
-    hookEvents
-    headers
-  }
+export function useCreateBitbucketHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateBitbucketHookMutation,
+    CreateBitbucketHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateBitbucketHookMutation,
+    CreateBitbucketHookMutationVariables
+  >(CreateBitbucketHookDocument, baseOptions);
 }
-    `;
-export type CreateGenericHookMutationFn = Apollo.MutationFunction<CreateGenericHookMutation, CreateGenericHookMutationVariables>;
+export type CreateBitbucketHookMutationHookResult = ReturnType<
+  typeof useCreateBitbucketHookMutation
+>;
+export type CreateBitbucketHookMutationResult = Apollo.MutationResult<
+  CreateBitbucketHookMutation
+>;
+export type CreateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateBitbucketHookMutation,
+  CreateBitbucketHookMutationVariables
+>;
+export const CreateGenericHookDocument = gql`
+  mutation createGenericHook($input: CreateGenericHookInput!) {
+    createGenericHook(input: $input) {
+      hookId
+      hookType
+      url
+      hookEvents
+      headers
+    }
+  }
+`;
+export type CreateGenericHookMutationFn = Apollo.MutationFunction<
+  CreateGenericHookMutation,
+  CreateGenericHookMutationVariables
+>;
 
 /**
  * __useCreateGenericHookMutation__
@@ -1173,26 +1557,43 @@ export type CreateGenericHookMutationFn = Apollo.MutationFunction<CreateGenericH
  *   },
  * });
  */
-export function useCreateGenericHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateGenericHookMutation, CreateGenericHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateGenericHookMutation, CreateGenericHookMutationVariables>(CreateGenericHookDocument, options);
-      }
-export type CreateGenericHookMutationHookResult = ReturnType<typeof useCreateGenericHookMutation>;
-export type CreateGenericHookMutationResult = Apollo.MutationResult<CreateGenericHookMutation>;
-export type CreateGenericHookMutationOptions = Apollo.BaseMutationOptions<CreateGenericHookMutation, CreateGenericHookMutationVariables>;
-export const CreateGithubHookDocument = gql`
-    mutation createGithubHook($input: CreateGithubHookInput!) {
-  createGithubHook(input: $input) {
-    projectId
-    hookId
-    hookType
-    url
-    githubToken
-    githubContext
-  }
+export function useCreateGenericHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateGenericHookMutation,
+    CreateGenericHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateGenericHookMutation,
+    CreateGenericHookMutationVariables
+  >(CreateGenericHookDocument, baseOptions);
 }
-    `;
-export type CreateGithubHookMutationFn = Apollo.MutationFunction<CreateGithubHookMutation, CreateGithubHookMutationVariables>;
+export type CreateGenericHookMutationHookResult = ReturnType<
+  typeof useCreateGenericHookMutation
+>;
+export type CreateGenericHookMutationResult = Apollo.MutationResult<
+  CreateGenericHookMutation
+>;
+export type CreateGenericHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateGenericHookMutation,
+  CreateGenericHookMutationVariables
+>;
+export const CreateGithubHookDocument = gql`
+  mutation createGithubHook($input: CreateGithubHookInput!) {
+    createGithubHook(input: $input) {
+      projectId
+      hookId
+      hookType
+      url
+      githubToken
+      githubContext
+    }
+  }
+`;
+export type CreateGithubHookMutationFn = Apollo.MutationFunction<
+  CreateGithubHookMutation,
+  CreateGithubHookMutationVariables
+>;
 
 /**
  * __useCreateGithubHookMutation__
@@ -1211,26 +1612,43 @@ export type CreateGithubHookMutationFn = Apollo.MutationFunction<CreateGithubHoo
  *   },
  * });
  */
-export function useCreateGithubHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateGithubHookMutation, CreateGithubHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateGithubHookMutation, CreateGithubHookMutationVariables>(CreateGithubHookDocument, options);
-      }
-export type CreateGithubHookMutationHookResult = ReturnType<typeof useCreateGithubHookMutation>;
-export type CreateGithubHookMutationResult = Apollo.MutationResult<CreateGithubHookMutation>;
-export type CreateGithubHookMutationOptions = Apollo.BaseMutationOptions<CreateGithubHookMutation, CreateGithubHookMutationVariables>;
-export const CreateSlackHookDocument = gql`
-    mutation createSlackHook($input: CreateSlackHookInput!) {
-  createSlackHook(input: $input) {
-    hookId
-    hookType
-    url
-    hookEvents
-    slackResultFilter
-    slackBranchFilter
-  }
+export function useCreateGithubHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateGithubHookMutation,
+    CreateGithubHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateGithubHookMutation,
+    CreateGithubHookMutationVariables
+  >(CreateGithubHookDocument, baseOptions);
 }
-    `;
-export type CreateSlackHookMutationFn = Apollo.MutationFunction<CreateSlackHookMutation, CreateSlackHookMutationVariables>;
+export type CreateGithubHookMutationHookResult = ReturnType<
+  typeof useCreateGithubHookMutation
+>;
+export type CreateGithubHookMutationResult = Apollo.MutationResult<
+  CreateGithubHookMutation
+>;
+export type CreateGithubHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateGithubHookMutation,
+  CreateGithubHookMutationVariables
+>;
+export const CreateSlackHookDocument = gql`
+  mutation createSlackHook($input: CreateSlackHookInput!) {
+    createSlackHook(input: $input) {
+      hookId
+      hookType
+      url
+      hookEvents
+      slackResultFilter
+      slackBranchFilter
+    }
+  }
+`;
+export type CreateSlackHookMutationFn = Apollo.MutationFunction<
+  CreateSlackHookMutation,
+  CreateSlackHookMutationVariables
+>;
 
 /**
  * __useCreateSlackHookMutation__
@@ -1249,24 +1667,41 @@ export type CreateSlackHookMutationFn = Apollo.MutationFunction<CreateSlackHookM
  *   },
  * });
  */
-export function useCreateSlackHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateSlackHookMutation, CreateSlackHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateSlackHookMutation, CreateSlackHookMutationVariables>(CreateSlackHookDocument, options);
-      }
-export type CreateSlackHookMutationHookResult = ReturnType<typeof useCreateSlackHookMutation>;
-export type CreateSlackHookMutationResult = Apollo.MutationResult<CreateSlackHookMutation>;
-export type CreateSlackHookMutationOptions = Apollo.BaseMutationOptions<CreateSlackHookMutation, CreateSlackHookMutationVariables>;
-export const CreateTeamsHookDocument = gql`
-    mutation createTeamsHook($input: CreateTeamsHookInput!) {
-  createTeamsHook(input: $input) {
-    hookId
-    hookType
-    url
-    hookEvents
-  }
+export function useCreateSlackHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateSlackHookMutation,
+    CreateSlackHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateSlackHookMutation,
+    CreateSlackHookMutationVariables
+  >(CreateSlackHookDocument, baseOptions);
 }
-    `;
-export type CreateTeamsHookMutationFn = Apollo.MutationFunction<CreateTeamsHookMutation, CreateTeamsHookMutationVariables>;
+export type CreateSlackHookMutationHookResult = ReturnType<
+  typeof useCreateSlackHookMutation
+>;
+export type CreateSlackHookMutationResult = Apollo.MutationResult<
+  CreateSlackHookMutation
+>;
+export type CreateSlackHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateSlackHookMutation,
+  CreateSlackHookMutationVariables
+>;
+export const CreateTeamsHookDocument = gql`
+  mutation createTeamsHook($input: CreateTeamsHookInput!) {
+    createTeamsHook(input: $input) {
+      hookId
+      hookType
+      url
+      hookEvents
+    }
+  }
+`;
+export type CreateTeamsHookMutationFn = Apollo.MutationFunction<
+  CreateTeamsHookMutation,
+  CreateTeamsHookMutationVariables
+>;
 
 /**
  * __useCreateTeamsHookMutation__
@@ -1285,22 +1720,39 @@ export type CreateTeamsHookMutationFn = Apollo.MutationFunction<CreateTeamsHookM
  *   },
  * });
  */
-export function useCreateTeamsHookMutation(baseOptions?: Apollo.MutationHookOptions<CreateTeamsHookMutation, CreateTeamsHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateTeamsHookMutation, CreateTeamsHookMutationVariables>(CreateTeamsHookDocument, options);
-      }
-export type CreateTeamsHookMutationHookResult = ReturnType<typeof useCreateTeamsHookMutation>;
-export type CreateTeamsHookMutationResult = Apollo.MutationResult<CreateTeamsHookMutation>;
-export type CreateTeamsHookMutationOptions = Apollo.BaseMutationOptions<CreateTeamsHookMutation, CreateTeamsHookMutationVariables>;
-export const DeleteHookDocument = gql`
-    mutation deleteHook($input: DeleteHookInput!) {
-  deleteHook(input: $input) {
-    hookId
-    projectId
-  }
+export function useCreateTeamsHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateTeamsHookMutation,
+    CreateTeamsHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    CreateTeamsHookMutation,
+    CreateTeamsHookMutationVariables
+  >(CreateTeamsHookDocument, baseOptions);
 }
-    `;
-export type DeleteHookMutationFn = Apollo.MutationFunction<DeleteHookMutation, DeleteHookMutationVariables>;
+export type CreateTeamsHookMutationHookResult = ReturnType<
+  typeof useCreateTeamsHookMutation
+>;
+export type CreateTeamsHookMutationResult = Apollo.MutationResult<
+  CreateTeamsHookMutation
+>;
+export type CreateTeamsHookMutationOptions = Apollo.BaseMutationOptions<
+  CreateTeamsHookMutation,
+  CreateTeamsHookMutationVariables
+>;
+export const DeleteHookDocument = gql`
+  mutation deleteHook($input: DeleteHookInput!) {
+    deleteHook(input: $input) {
+      hookId
+      projectId
+    }
+  }
+`;
+export type DeleteHookMutationFn = Apollo.MutationFunction<
+  DeleteHookMutation,
+  DeleteHookMutationVariables
+>;
 
 /**
  * __useDeleteHookMutation__
@@ -1319,21 +1771,38 @@ export type DeleteHookMutationFn = Apollo.MutationFunction<DeleteHookMutation, D
  *   },
  * });
  */
-export function useDeleteHookMutation(baseOptions?: Apollo.MutationHookOptions<DeleteHookMutation, DeleteHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteHookMutation, DeleteHookMutationVariables>(DeleteHookDocument, options);
-      }
-export type DeleteHookMutationHookResult = ReturnType<typeof useDeleteHookMutation>;
-export type DeleteHookMutationResult = Apollo.MutationResult<DeleteHookMutation>;
-export type DeleteHookMutationOptions = Apollo.BaseMutationOptions<DeleteHookMutation, DeleteHookMutationVariables>;
-export const UpdateBitbucketHookDocument = gql`
-    mutation updateBitbucketHook($input: UpdateBitbucketHookInput!) {
-  updateBitbucketHook(input: $input) {
-    hookId
-  }
+export function useDeleteHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteHookMutation,
+    DeleteHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<DeleteHookMutation, DeleteHookMutationVariables>(
+    DeleteHookDocument,
+    baseOptions
+  );
 }
-    `;
-export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>;
+export type DeleteHookMutationHookResult = ReturnType<
+  typeof useDeleteHookMutation
+>;
+export type DeleteHookMutationResult = Apollo.MutationResult<
+  DeleteHookMutation
+>;
+export type DeleteHookMutationOptions = Apollo.BaseMutationOptions<
+  DeleteHookMutation,
+  DeleteHookMutationVariables
+>;
+export const UpdateBitbucketHookDocument = gql`
+  mutation updateBitbucketHook($input: UpdateBitbucketHookInput!) {
+    updateBitbucketHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<
+  UpdateBitbucketHookMutation,
+  UpdateBitbucketHookMutationVariables
+>;
 
 /**
  * __useUpdateBitbucketHookMutation__
@@ -1352,21 +1821,38 @@ export type UpdateBitbucketHookMutationFn = Apollo.MutationFunction<UpdateBitbuc
  *   },
  * });
  */
-export function useUpdateBitbucketHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>(UpdateBitbucketHookDocument, options);
-      }
-export type UpdateBitbucketHookMutationHookResult = ReturnType<typeof useUpdateBitbucketHookMutation>;
-export type UpdateBitbucketHookMutationResult = Apollo.MutationResult<UpdateBitbucketHookMutation>;
-export type UpdateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<UpdateBitbucketHookMutation, UpdateBitbucketHookMutationVariables>;
-export const UpdateGenericHookDocument = gql`
-    mutation updateGenericHook($input: UpdateGenericHookInput!) {
-  updateGenericHook(input: $input) {
-    hookId
-  }
+export function useUpdateBitbucketHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateBitbucketHookMutation,
+    UpdateBitbucketHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateBitbucketHookMutation,
+    UpdateBitbucketHookMutationVariables
+  >(UpdateBitbucketHookDocument, baseOptions);
 }
-    `;
-export type UpdateGenericHookMutationFn = Apollo.MutationFunction<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>;
+export type UpdateBitbucketHookMutationHookResult = ReturnType<
+  typeof useUpdateBitbucketHookMutation
+>;
+export type UpdateBitbucketHookMutationResult = Apollo.MutationResult<
+  UpdateBitbucketHookMutation
+>;
+export type UpdateBitbucketHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateBitbucketHookMutation,
+  UpdateBitbucketHookMutationVariables
+>;
+export const UpdateGenericHookDocument = gql`
+  mutation updateGenericHook($input: UpdateGenericHookInput!) {
+    updateGenericHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateGenericHookMutationFn = Apollo.MutationFunction<
+  UpdateGenericHookMutation,
+  UpdateGenericHookMutationVariables
+>;
 
 /**
  * __useUpdateGenericHookMutation__
@@ -1385,21 +1871,38 @@ export type UpdateGenericHookMutationFn = Apollo.MutationFunction<UpdateGenericH
  *   },
  * });
  */
-export function useUpdateGenericHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>(UpdateGenericHookDocument, options);
-      }
-export type UpdateGenericHookMutationHookResult = ReturnType<typeof useUpdateGenericHookMutation>;
-export type UpdateGenericHookMutationResult = Apollo.MutationResult<UpdateGenericHookMutation>;
-export type UpdateGenericHookMutationOptions = Apollo.BaseMutationOptions<UpdateGenericHookMutation, UpdateGenericHookMutationVariables>;
-export const UpdateGithubHookDocument = gql`
-    mutation updateGithubHook($input: UpdateGithubHookInput!) {
-  updateGithubHook(input: $input) {
-    hookId
-  }
+export function useUpdateGenericHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateGenericHookMutation,
+    UpdateGenericHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateGenericHookMutation,
+    UpdateGenericHookMutationVariables
+  >(UpdateGenericHookDocument, baseOptions);
 }
-    `;
-export type UpdateGithubHookMutationFn = Apollo.MutationFunction<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>;
+export type UpdateGenericHookMutationHookResult = ReturnType<
+  typeof useUpdateGenericHookMutation
+>;
+export type UpdateGenericHookMutationResult = Apollo.MutationResult<
+  UpdateGenericHookMutation
+>;
+export type UpdateGenericHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateGenericHookMutation,
+  UpdateGenericHookMutationVariables
+>;
+export const UpdateGithubHookDocument = gql`
+  mutation updateGithubHook($input: UpdateGithubHookInput!) {
+    updateGithubHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateGithubHookMutationFn = Apollo.MutationFunction<
+  UpdateGithubHookMutation,
+  UpdateGithubHookMutationVariables
+>;
 
 /**
  * __useUpdateGithubHookMutation__
@@ -1418,21 +1921,38 @@ export type UpdateGithubHookMutationFn = Apollo.MutationFunction<UpdateGithubHoo
  *   },
  * });
  */
-export function useUpdateGithubHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>(UpdateGithubHookDocument, options);
-      }
-export type UpdateGithubHookMutationHookResult = ReturnType<typeof useUpdateGithubHookMutation>;
-export type UpdateGithubHookMutationResult = Apollo.MutationResult<UpdateGithubHookMutation>;
-export type UpdateGithubHookMutationOptions = Apollo.BaseMutationOptions<UpdateGithubHookMutation, UpdateGithubHookMutationVariables>;
-export const UpdateSlackHookDocument = gql`
-    mutation updateSlackHook($input: UpdateSlackHookInput!) {
-  updateSlackHook(input: $input) {
-    hookId
-  }
+export function useUpdateGithubHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateGithubHookMutation,
+    UpdateGithubHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateGithubHookMutation,
+    UpdateGithubHookMutationVariables
+  >(UpdateGithubHookDocument, baseOptions);
 }
-    `;
-export type UpdateSlackHookMutationFn = Apollo.MutationFunction<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>;
+export type UpdateGithubHookMutationHookResult = ReturnType<
+  typeof useUpdateGithubHookMutation
+>;
+export type UpdateGithubHookMutationResult = Apollo.MutationResult<
+  UpdateGithubHookMutation
+>;
+export type UpdateGithubHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateGithubHookMutation,
+  UpdateGithubHookMutationVariables
+>;
+export const UpdateSlackHookDocument = gql`
+  mutation updateSlackHook($input: UpdateSlackHookInput!) {
+    updateSlackHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateSlackHookMutationFn = Apollo.MutationFunction<
+  UpdateSlackHookMutation,
+  UpdateSlackHookMutationVariables
+>;
 
 /**
  * __useUpdateSlackHookMutation__
@@ -1451,21 +1971,38 @@ export type UpdateSlackHookMutationFn = Apollo.MutationFunction<UpdateSlackHookM
  *   },
  * });
  */
-export function useUpdateSlackHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>(UpdateSlackHookDocument, options);
-      }
-export type UpdateSlackHookMutationHookResult = ReturnType<typeof useUpdateSlackHookMutation>;
-export type UpdateSlackHookMutationResult = Apollo.MutationResult<UpdateSlackHookMutation>;
-export type UpdateSlackHookMutationOptions = Apollo.BaseMutationOptions<UpdateSlackHookMutation, UpdateSlackHookMutationVariables>;
-export const UpdateTeamsHookDocument = gql`
-    mutation updateTeamsHook($input: UpdateTeamsHookInput!) {
-  updateTeamsHook(input: $input) {
-    hookId
-  }
+export function useUpdateSlackHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateSlackHookMutation,
+    UpdateSlackHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateSlackHookMutation,
+    UpdateSlackHookMutationVariables
+  >(UpdateSlackHookDocument, baseOptions);
 }
-    `;
-export type UpdateTeamsHookMutationFn = Apollo.MutationFunction<UpdateTeamsHookMutation, UpdateTeamsHookMutationVariables>;
+export type UpdateSlackHookMutationHookResult = ReturnType<
+  typeof useUpdateSlackHookMutation
+>;
+export type UpdateSlackHookMutationResult = Apollo.MutationResult<
+  UpdateSlackHookMutation
+>;
+export type UpdateSlackHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateSlackHookMutation,
+  UpdateSlackHookMutationVariables
+>;
+export const UpdateTeamsHookDocument = gql`
+  mutation updateTeamsHook($input: UpdateTeamsHookInput!) {
+    updateTeamsHook(input: $input) {
+      hookId
+    }
+  }
+`;
+export type UpdateTeamsHookMutationFn = Apollo.MutationFunction<
+  UpdateTeamsHookMutation,
+  UpdateTeamsHookMutationVariables
+>;
 
 /**
  * __useUpdateTeamsHookMutation__
@@ -1484,23 +2021,40 @@ export type UpdateTeamsHookMutationFn = Apollo.MutationFunction<UpdateTeamsHookM
  *   },
  * });
  */
-export function useUpdateTeamsHookMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTeamsHookMutation, UpdateTeamsHookMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateTeamsHookMutation, UpdateTeamsHookMutationVariables>(UpdateTeamsHookDocument, options);
-      }
-export type UpdateTeamsHookMutationHookResult = ReturnType<typeof useUpdateTeamsHookMutation>;
-export type UpdateTeamsHookMutationResult = Apollo.MutationResult<UpdateTeamsHookMutation>;
-export type UpdateTeamsHookMutationOptions = Apollo.BaseMutationOptions<UpdateTeamsHookMutation, UpdateTeamsHookMutationVariables>;
-export const UpdateProjectDocument = gql`
-    mutation updateProject($input: UpdateProjectInput!) {
-  updateProject(input: $input) {
-    projectId
-    inactivityTimeoutSeconds
-    projectColor
-  }
+export function useUpdateTeamsHookMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateTeamsHookMutation,
+    UpdateTeamsHookMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateTeamsHookMutation,
+    UpdateTeamsHookMutationVariables
+  >(UpdateTeamsHookDocument, baseOptions);
 }
-    `;
-export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateTeamsHookMutationHookResult = ReturnType<
+  typeof useUpdateTeamsHookMutation
+>;
+export type UpdateTeamsHookMutationResult = Apollo.MutationResult<
+  UpdateTeamsHookMutation
+>;
+export type UpdateTeamsHookMutationOptions = Apollo.BaseMutationOptions<
+  UpdateTeamsHookMutation,
+  UpdateTeamsHookMutationVariables
+>;
+export const UpdateProjectDocument = gql`
+  mutation updateProject($input: UpdateProjectInput!) {
+    updateProject(input: $input) {
+      projectId
+      inactivityTimeoutSeconds
+      projectColor
+    }
+  }
+`;
+export type UpdateProjectMutationFn = Apollo.MutationFunction<
+  UpdateProjectMutation,
+  UpdateProjectMutationVariables
+>;
 
 /**
  * __useUpdateProjectMutation__
@@ -1519,23 +2073,40 @@ export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutat
  *   },
  * });
  */
-export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, options);
-      }
-export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
-export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
-export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
-export const DeleteRunDocument = gql`
-    mutation deleteRun($runId: ID!) {
-  deleteRun(runId: $runId) {
-    success
-    message
-    runIds
-  }
+export function useUpdateProjectMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateProjectMutation,
+    UpdateProjectMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    UpdateProjectMutation,
+    UpdateProjectMutationVariables
+  >(UpdateProjectDocument, baseOptions);
 }
-    `;
-export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
+export type UpdateProjectMutationHookResult = ReturnType<
+  typeof useUpdateProjectMutation
+>;
+export type UpdateProjectMutationResult = Apollo.MutationResult<
+  UpdateProjectMutation
+>;
+export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<
+  UpdateProjectMutation,
+  UpdateProjectMutationVariables
+>;
+export const DeleteRunDocument = gql`
+  mutation deleteRun($runId: ID!) {
+    deleteRun(runId: $runId) {
+      success
+      message
+      runIds
+    }
+  }
+`;
+export type DeleteRunMutationFn = Apollo.MutationFunction<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
 
 /**
  * __useDeleteRunMutation__
@@ -1554,22 +2125,34 @@ export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, Del
  *   },
  * });
  */
-export function useDeleteRunMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, options);
-      }
-export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
-export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutation>;
-export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
-export const GetSpecStatsDocument = gql`
-    query getSpecStats($spec: String!) {
-  specStats(spec: $spec) {
-    spec
-    count
-    avgWallClockDuration
-  }
+export function useDeleteRunMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteRunMutation,
+    DeleteRunMutationVariables
+  >
+) {
+  return Apollo.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(
+    DeleteRunDocument,
+    baseOptions
+  );
 }
-    `;
+export type DeleteRunMutationHookResult = ReturnType<
+  typeof useDeleteRunMutation
+>;
+export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutation>;
+export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<
+  DeleteRunMutation,
+  DeleteRunMutationVariables
+>;
+export const GetSpecStatsDocument = gql`
+  query getSpecStats($spec: String!) {
+    specStats(spec: $spec) {
+      spec
+      count
+      avgWallClockDuration
+    }
+  }
+`;
 
 /**
  * __useGetSpecStatsQuery__
@@ -1587,40 +2170,62 @@ export const GetSpecStatsDocument = gql`
  *   },
  * });
  */
-export function useGetSpecStatsQuery(baseOptions: Apollo.QueryHookOptions<GetSpecStatsQuery, GetSpecStatsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(GetSpecStatsDocument, options);
-      }
-export function useGetSpecStatsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSpecStatsQuery, GetSpecStatsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(GetSpecStatsDocument, options);
-        }
-export type GetSpecStatsQueryHookResult = ReturnType<typeof useGetSpecStatsQuery>;
-export type GetSpecStatsLazyQueryHookResult = ReturnType<typeof useGetSpecStatsLazyQuery>;
-export type GetSpecStatsQueryResult = Apollo.QueryResult<GetSpecStatsQuery, GetSpecStatsQueryVariables>;
+export function useGetSpecStatsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetSpecStatsQuery,
+    GetSpecStatsQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(
+    GetSpecStatsDocument,
+    baseOptions
+  );
+}
+export function useGetSpecStatsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetSpecStatsQuery,
+    GetSpecStatsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetSpecStatsQuery, GetSpecStatsQueryVariables>(
+    GetSpecStatsDocument,
+    baseOptions
+  );
+}
+export type GetSpecStatsQueryHookResult = ReturnType<
+  typeof useGetSpecStatsQuery
+>;
+export type GetSpecStatsLazyQueryHookResult = ReturnType<
+  typeof useGetSpecStatsLazyQuery
+>;
+export type GetSpecStatsQueryResult = Apollo.QueryResult<
+  GetSpecStatsQuery,
+  GetSpecStatsQueryVariables
+>;
 export const GetRunDocument = gql`
-    query getRun($runId: ID!) {
-  run(id: $runId) {
-    runId
-    createdAt
-    completion {
-      ...RunSummaryCompletion
-    }
-    meta {
-      ...RunSummaryMeta
-    }
-    specs {
-      ...RunDetailSpec
-    }
-    progress {
-      ...RunProgress
+  query getRun($runId: ID!) {
+    run(id: $runId) {
+      runId
+      createdAt
+      completion {
+        ...RunSummaryCompletion
+      }
+      meta {
+        ...RunSummaryMeta
+      }
+      specs {
+        ...RunDetailSpec
+      }
+      progress {
+        ...RunProgress
+      }
     }
   }
-}
-    ${RunSummaryCompletionFragmentDoc}
-${RunSummaryMetaFragmentDoc}
-${RunDetailSpecFragmentDoc}
-${RunProgressFragmentDoc}`;
+  ${RunSummaryCompletionFragmentDoc}
+  ${RunSummaryMetaFragmentDoc}
+  ${RunDetailSpecFragmentDoc}
+  ${RunProgressFragmentDoc}
+`;
 
 /**
  * __useGetRunQuery__
@@ -1638,27 +2243,41 @@ ${RunProgressFragmentDoc}`;
  *   },
  * });
  */
-export function useGetRunQuery(baseOptions: Apollo.QueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, options);
-      }
-export function useGetRunLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetRunQuery, GetRunQueryVariables>(GetRunDocument, options);
-        }
+export function useGetRunQuery(
+  baseOptions: Apollo.QueryHookOptions<GetRunQuery, GetRunQueryVariables>
+) {
+  return Apollo.useQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
+}
+export function useGetRunLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetRunQuery, GetRunQueryVariables>
+) {
+  return Apollo.useLazyQuery<GetRunQuery, GetRunQueryVariables>(
+    GetRunDocument,
+    baseOptions
+  );
+}
 export type GetRunQueryHookResult = ReturnType<typeof useGetRunQuery>;
 export type GetRunLazyQueryHookResult = ReturnType<typeof useGetRunLazyQuery>;
-export type GetRunQueryResult = Apollo.QueryResult<GetRunQuery, GetRunQueryVariables>;
+export type GetRunQueryResult = Apollo.QueryResult<
+  GetRunQuery,
+  GetRunQueryVariables
+>;
 export const ResetInstanceDocument = gql`
-    mutation resetInstance($instanceId: ID!) {
-  resetInstance(instanceId: $instanceId) {
-    success
-    message
-    instanceId
+  mutation resetInstance($instanceId: ID!) {
+    resetInstance(instanceId: $instanceId) {
+      success
+      message
+      instanceId
+    }
   }
-}
-    `;
-export type ResetInstanceMutationFn = Apollo.MutationFunction<ResetInstanceMutation, ResetInstanceMutationVariables>;
+`;
+export type ResetInstanceMutationFn = Apollo.MutationFunction<
+  ResetInstanceMutation,
+  ResetInstanceMutationVariables
+>;
 
 /**
  * __useResetInstanceMutation__
@@ -1677,36 +2296,51 @@ export type ResetInstanceMutationFn = Apollo.MutationFunction<ResetInstanceMutat
  *   },
  * });
  */
-export function useResetInstanceMutation(baseOptions?: Apollo.MutationHookOptions<ResetInstanceMutation, ResetInstanceMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<ResetInstanceMutation, ResetInstanceMutationVariables>(ResetInstanceDocument, options);
-      }
-export type ResetInstanceMutationHookResult = ReturnType<typeof useResetInstanceMutation>;
-export type ResetInstanceMutationResult = Apollo.MutationResult<ResetInstanceMutation>;
-export type ResetInstanceMutationOptions = Apollo.BaseMutationOptions<ResetInstanceMutation, ResetInstanceMutationVariables>;
+export function useResetInstanceMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    ResetInstanceMutation,
+    ResetInstanceMutationVariables
+  >
+) {
+  return Apollo.useMutation<
+    ResetInstanceMutation,
+    ResetInstanceMutationVariables
+  >(ResetInstanceDocument, baseOptions);
+}
+export type ResetInstanceMutationHookResult = ReturnType<
+  typeof useResetInstanceMutation
+>;
+export type ResetInstanceMutationResult = Apollo.MutationResult<
+  ResetInstanceMutation
+>;
+export type ResetInstanceMutationOptions = Apollo.BaseMutationOptions<
+  ResetInstanceMutation,
+  ResetInstanceMutationVariables
+>;
 export const GetRunsFeedDocument = gql`
-    query getRunsFeed($cursor: String, $filters: [Filters!]!) {
-  runFeed(cursor: $cursor, filters: $filters) {
-    cursor
-    hasMore
-    runs {
-      runId
-      createdAt
-      completion {
-        ...RunSummaryCompletion
-      }
-      meta {
-        ...RunSummaryMeta
-      }
-      progress {
-        ...RunProgress
+  query getRunsFeed($cursor: String, $filters: [Filters!]!) {
+    runFeed(cursor: $cursor, filters: $filters) {
+      cursor
+      hasMore
+      runs {
+        runId
+        createdAt
+        completion {
+          ...RunSummaryCompletion
+        }
+        meta {
+          ...RunSummaryMeta
+        }
+        progress {
+          ...RunProgress
+        }
       }
     }
   }
-}
-    ${RunSummaryCompletionFragmentDoc}
-${RunSummaryMetaFragmentDoc}
-${RunProgressFragmentDoc}`;
+  ${RunSummaryCompletionFragmentDoc}
+  ${RunSummaryMetaFragmentDoc}
+  ${RunProgressFragmentDoc}
+`;
 
 /**
  * __useGetRunsFeedQuery__
@@ -1725,25 +2359,43 @@ ${RunProgressFragmentDoc}`;
  *   },
  * });
  */
-export function useGetRunsFeedQuery(baseOptions: Apollo.QueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, options);
-      }
-export function useGetRunsFeedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRunsFeedQuery, GetRunsFeedQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(GetRunsFeedDocument, options);
-        }
+export function useGetRunsFeedQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return Apollo.useQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
+    GetRunsFeedDocument,
+    baseOptions
+  );
+}
+export function useGetRunsFeedLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetRunsFeedQuery,
+    GetRunsFeedQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<GetRunsFeedQuery, GetRunsFeedQueryVariables>(
+    GetRunsFeedDocument,
+    baseOptions
+  );
+}
 export type GetRunsFeedQueryHookResult = ReturnType<typeof useGetRunsFeedQuery>;
-export type GetRunsFeedLazyQueryHookResult = ReturnType<typeof useGetRunsFeedLazyQuery>;
-export type GetRunsFeedQueryResult = Apollo.QueryResult<GetRunsFeedQuery, GetRunsFeedQueryVariables>;
+export type GetRunsFeedLazyQueryHookResult = ReturnType<
+  typeof useGetRunsFeedLazyQuery
+>;
+export type GetRunsFeedQueryResult = Apollo.QueryResult<
+  GetRunsFeedQuery,
+  GetRunsFeedQueryVariables
+>;
 
-      export interface PossibleTypesResultData {
-        possibleTypes: {
-          [key: string]: string[]
-        }
-      }
-      const result: PossibleTypesResultData = {
-  "possibleTypes": {}
+export interface PossibleTypesResultData {
+  possibleTypes: {
+    [key: string]: string[];
+  };
+}
+const result: PossibleTypesResultData = {
+  possibleTypes: {},
 };
-      export default result;
-    
+export default result;

--- a/packages/dashboard/src/instance/instanceSummary.tsx
+++ b/packages/dashboard/src/instance/instanceSummary.tsx
@@ -1,4 +1,5 @@
 import {
+  AccessTime,
   CheckCircleOutline,
   ErrorOutline,
   Flaky,
@@ -105,10 +106,20 @@ export const InstanceSummary: InstanceSummaryComponent = (props) => {
           <Grid item>
             <Tooltip title="Skipped Tests" arrow>
               <Chip
-                color={stats['pending'] ? 'orange' : 'grey'}
+                color={stats['skipped'] ? 'orange' : 'grey'}
+                shade={!stats['skipped'] ? 300 : undefined}
+                label={<Pad number={stats['skipped']} />}
+                icon={NextPlanOutlined}
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Pending Tests" arrow>
+              <Chip
+                color={stats['pending'] ? 'cyan' : 'grey'}
                 shade={!stats['pending'] ? 300 : undefined}
                 label={<Pad number={stats['pending']} />}
-                icon={NextPlanOutlined}
+                icon={AccessTime}
               />
             </Tooltip>
           </Grid>

--- a/packages/dashboard/src/run/runDetails/runDetails.tsx
+++ b/packages/dashboard/src/run/runDetails/runDetails.tsx
@@ -4,6 +4,7 @@ import {
   Paper,
   RenderOnInterval,
   TestFailureChip,
+  TestOverallChip,
   TestRetriesChip,
   TestSkippedChip,
   TestSuccessChip,
@@ -35,10 +36,10 @@ export const RunDetails: RunDetailsComponent = (props) => {
     return null;
   }
 
-  const rows = useMemo(
-    () => convertToRows(run, hidePassedSpecs),
-    [run, hidePassedSpecs]
-  );
+  const rows = useMemo(() => convertToRows(run, hidePassedSpecs), [
+    run,
+    hidePassedSpecs,
+  ]);
 
   return (
     <Paper sx={{ p: 0 }}>
@@ -90,7 +91,7 @@ export const RunDetails: RunDetailsComponent = (props) => {
             sortable: false,
             filterable: false,
             renderCell: getTestStatsCell,
-            minWidth: 280,
+            minWidth: 360,
           },
           {
             field: 'actions',
@@ -162,6 +163,9 @@ const getTestStatsCell = (params: GridRenderCellParams) => {
   return (
     <Grid container spacing={1}>
       <Grid item>
+        <TestOverallChip value={params.row.results?.stats?.tests ?? 0} />
+      </Grid>
+      <Grid item>
         <TestSuccessChip value={params.row.results?.stats?.passes ?? 0} />
       </Grid>
       <Grid item>
@@ -171,8 +175,11 @@ const getTestStatsCell = (params: GridRenderCellParams) => {
         <TestRetriesChip value={params.row.results?.retries ?? 0} />
       </Grid>
       <Grid item>
-        <TestSkippedChip value={params.row.results?.stats?.pending ?? 0} />
+        <TestSkippedChip value={params.row.results?.stats?.skipped ?? 0} />
       </Grid>
+      {/*<Grid item>*/}
+      {/*    <TestPendingChip value={params.row.results?.stats?.pending ?? 0} />*/}
+      {/*</Grid>*/}
     </Grid>
   );
 };

--- a/packages/dashboard/src/run/runSummary/runSummary.tsx
+++ b/packages/dashboard/src/run/runSummary/runSummary.tsx
@@ -23,6 +23,17 @@ import { RunStartTime } from '../runStartTime';
 import { RunSummaryTestResults } from '../runSummaryTestResults';
 import { RunTimeoutChip } from '../runTimeoutChip';
 
+function getTotalFromSpecResults(specs?: any[]) {
+  if (!specs) return undefined;
+  let total = 0;
+
+  specs.forEach((spec) => {
+    total += spec.results?.stats?.tests ?? 0;
+  });
+
+  return total;
+}
+
 export const RunSummary: RunSummaryComponent = (props) => {
   const {
     run,

--- a/packages/dashboard/src/run/runSummaryTestResults/runSummaryTestResults.tsx
+++ b/packages/dashboard/src/run/runSummaryTestResults/runSummaryTestResults.tsx
@@ -2,6 +2,7 @@ import { Grid } from '@mui/material';
 import {
   TestFailureChip,
   TestOverallChip,
+  TestPendingChip,
   TestRetriesChip,
   TestSkippedChip,
   TestSuccessChip,
@@ -28,7 +29,10 @@ export const RunSummaryTestResults: RunSummaryTestResultsComponent = (
         <TestRetriesChip value={testsStats.retries} />
       </Grid>
       <Grid item>
-        <TestSkippedChip value={testsStats.pending} />
+        <TestSkippedChip value={testsStats.skipped} />
+      </Grid>
+      <Grid item>
+        <TestPendingChip value={testsStats.pending} />
       </Grid>
     </Grid>
   );
@@ -44,6 +48,7 @@ type TestStats = {
 };
 type RunSummaryTestResultsProps = {
   testsStats: TestStats;
+  totalCount?: number;
 };
 type RunSummaryTestResultsComponent = FunctionComponent<
   RunSummaryTestResultsProps

--- a/packages/director/src/api/instances.ts
+++ b/packages/director/src/api/instances.ts
@@ -104,7 +104,7 @@ export const setInstanceTests: RequestHandler<
   const { instanceId } = req.params;
   const executionDriver = await getExecutionDriver();
 
-  getLogger().log({ instanceId }, 'Received instance tests');
+  getLogger().log({ instanceId, ...req.body }, 'Received instance tests');
   await executionDriver.setInstanceTests(instanceId, instanceTests);
   res.json({});
 };

--- a/packages/director/src/execution/mongo/instances/instance.controller.ts
+++ b/packages/director/src/execution/mongo/instances/instance.controller.ts
@@ -1,4 +1,4 @@
-import { SetInstanceTestsPayload } from '@sorry-cypress/common';
+import { SetInstanceTestsPayload, TestState } from '@sorry-cypress/common';
 import {
   AppError,
   INSTANCE_NOT_EXIST,
@@ -62,9 +62,11 @@ export const setInstanceTests = async (
     { instanceId, runId: instance.runId, groupId: instance.groupId },
     'Updating group progress'
   );
+
   await incProgressOverallTests(
     instance.runId,
     instance.groupId,
+    instance.instanceId,
     payload.tests.length
   );
 };
@@ -82,6 +84,21 @@ export const updateInstanceResults: ExecutionDriver['updateInstanceResults'] = a
     );
     throw new AppError(INSTANCE_NOT_EXIST);
   }
+
+  // Correct for Mocha madness, where tests which are deliberately skipped are marked as 'pending'.
+  // Since the test is finished when we get this result, it should be safe to say that no test should actually be pending at this point.
+  update.stats.failures += update.stats.skipped; // things that cypress reports as skipped are things skipped after a failure
+  update.stats.skipped = update.stats.pending; // things that cypress reports as pending are skipped by mocha
+  update.stats.pending = 0; // things can never be pending after execution is complete
+
+  update.tests.forEach((test) => {
+    if (test.state === TestState.Skipped) {
+      test.state = TestState.Failed;
+    }
+    if (test.state === TestState.Pending) {
+      test.state = TestState.Skipped;
+    }
+  });
 
   const instanceResult = mergeInstanceResults(
     instance._createTestsPayload,

--- a/packages/director/src/execution/mongo/runs/run.model.ts
+++ b/packages/director/src/execution/mongo/runs/run.model.ts
@@ -45,6 +45,7 @@ export const addSpecsToRun = async (runId: string, specs: RunSpec[]) => {
 export const incProgressOverallTests = async (
   runId: string,
   groupId: string,
+  instanceId: string,
   inc: number
 ) => {
   await Collection.run().updateOne(
@@ -58,6 +59,20 @@ export const incProgressOverallTests = async (
     },
     {
       arrayFilters: [{ 'group.groupId': groupId }],
+    }
+  );
+  // store the number of tests indicated when testing starts
+  await Collection.run().updateOne(
+    {
+      runId,
+    },
+    {
+      $set: {
+        'specs.$[specs].tests': inc,
+      },
+    },
+    {
+      arrayFilters: [{ 'specs.instanceId': instanceId }],
     }
   );
 };


### PR DESCRIPTION
This modifies the code in the director that receives statuses from cypress, and converts those statuses to something that makes sense in the sorry-cypress interface.

This is relation to the issues described in #555, but also my own issues trying to query the sorry cypress API and getting a whole bunch of pending tests back when my tests are already complete.

When directory receives the following statuses from cypress they're converted:

- `pending`: converted into `skipped`
- `skipped`: converted into `failed`, this should really remain 'skipped', but I can't make a distinction between error-skipped, and desired skipped

This will result in the interface never displaying any pending tests if the instance has completed.

It also adds display for total number of tests per instance/run/tests pretty much anywhere in the interface. There is still some discrepancy somewhere between what `setInstanceTests` reports initially, and what is later returned as the total by `updateInstanceResults`, but I haven't been able to figure out why that is.