### PR TITLE
feat: add indexes to speed up the runs page and ci build redirect query

### DIFF
--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -1,27 +1,31 @@
 export interface AggregationFilter {
   key: string;
   value?: string;
-  like?: string;
+  like?: string | null;
 }
 
 export const filtersToAggregations = (filters?: AggregationFilter[]) => {
   if (!filters) {
     return [];
   }
-  return filters
+  const match = {};
+  filters
     .filter(({ like, value }) => like !== undefined || value !== undefined)
-    .map((filter) => ({
-      $match: {
-        [filter.key]: buildFilterExpression(filter),
-      },
-    }));
+    .forEach((filter) => {
+      match[filter.key] = buildFilterExpression(filter);
+    });
+  return [
+    {
+      $match: match,
+    },
+  ];
 };
 
 const buildFilterExpression = ({ like, value }: AggregationFilter) => {
   if (value !== undefined) {
     return value;
   }
-  if (like !== undefined) {
+  if (like !== undefined && like !== null) {
     return {
       $regex: RegExp(like.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'i'),
     };

--- a/packages/dashboard/src/run/runsFeed/useGetCiBuildId.ts
+++ b/packages/dashboard/src/run/runsFeed/useGetCiBuildId.ts
@@ -1,0 +1,38 @@
+import { ApolloError } from '@apollo/client';
+import {
+  GetRunsFeedQuery,
+  useGetRunsFeedQuery,
+} from '@sorry-cypress/dashboard/generated/graphql';
+
+interface UseGetCiBuildId {
+  projectId: string;
+  ciBuildId: string;
+}
+export const useGetCiBuildId = ({
+  projectId,
+  ciBuildId,
+}: UseGetCiBuildId): [
+  GetRunsFeedQuery['runFeed'] | undefined,
+  boolean,
+  ApolloError | undefined
+] => {
+  const { loading, error, data } = useGetRunsFeedQuery({
+    variables: {
+      filters: [
+        {
+          key: 'meta.ciBuildId',
+          like: null,
+          value: ciBuildId,
+        },
+        {
+          key: 'meta.projectId',
+          like: null,
+          value: projectId,
+        },
+      ],
+      cursor: '',
+    },
+  });
+
+  return [data?.runFeed, loading, error];
+};

--- a/packages/dashboard/src/run/runsRedirect.tsx
+++ b/packages/dashboard/src/run/runsRedirect.tsx
@@ -1,17 +1,13 @@
+import { useGetCiBuildId } from '@sorry-cypress/dashboard/run/runsFeed/useGetCiBuildId';
 import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
-import { useGetRunsFeed } from './runsFeed/useGetRunFeed';
-
-type RunRedirectProps = {
-  // nothing yet
-};
 
 export function RunRedirect() {
   const { projectId, buildId } = useParams();
 
-  const [runsFeed, , loading] = useGetRunsFeed({
+  const [runsFeed, , loading] = useGetCiBuildId({
     projectId: projectId!,
-    search: buildId,
+    ciBuildId: buildId!,
   });
 
   return !loading && runsFeed && runsFeed.runs.length > 0 ? (

--- a/packages/mongo/src/db.ts
+++ b/packages/mongo/src/db.ts
@@ -75,6 +75,19 @@ async function createIndexes() {
     Collection.run().createIndex({ 'meta.commit.message': 1 }),
     Collection.run().createIndex({ 'meta.ciBuildId': 1 }),
 
+    // for aggregations on runs (/[projectId]/runs)
+    Collection.run().createIndex({
+      'meta.projectId': 1,
+      _id: 1,
+    }),
+
+    // for aggregations on runs (/[projectId]/runs/[ciBuildId])
+    Collection.run().createIndex({
+      'meta.projectId': 1,
+      'meta.ciBuildId': 1,
+      _id: 1,
+    }),
+
     Collection.instance().createIndex({ instanceId: 1 }, { unique: true }),
     Collection.instance().createIndex({ runId: 1 }),
     Collection.project().createIndex({ projectId: 1 }, { unique: true }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,7 +4110,7 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
   integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10":
+"@types/serve-static@*", "@types/serve-static@1.13.10", "@types/serve-static@^1.13.10":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -6449,6 +6449,7 @@ degenerator@^3.0.2:
     ast-types "^0.13.2"
     escodegen "^1.8.1"
     esprima "^4.0.0"
+    vm2 "^3.9.8"
 
 del@^6.0.0:
   version "6.0.0"
@@ -13306,7 +13307,7 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tslib@^2.4.0:
+tslib@^2.2.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
These additions improve the speed of the `/[project]/runs` page when you have a large number of runs. Previous aggregation query was only using an index for sorting, but still had to page through all runs to filter the results.

I also replaced the `/[project]/runs/[ciBuildId]` query to take advantage of the new indexes (previous query was using a regular expression match for something that was guaranteed to be the full value).
