### PR TITLE
Enhance sidebar layout

### DIFF
--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -126,7 +126,6 @@ const Drawer = styled(MuiDrawer, {
   return {
     width: DRAWER_WIDTH,
     flexShrink: 0,
-    whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     ...(open && {
       ...openedMixin(theme),
@@ -160,7 +159,6 @@ export const ProjectListMenu: ProjectListMenuType = ({
           return (
             <ListItemButton
               key={decodeURIComponent(project.projectId)}
-              sx={{ pl: 4 }}
               component={RouterLink}
               to={`/${encodeURIComponent(project.projectId)}/runs`}
               onClick={onItemClick}
@@ -173,7 +171,7 @@ export const ProjectListMenu: ProjectListMenuType = ({
               <ListItemText
                 primary={decodeURIComponent(project.projectId)}
                 primaryTypographyProps={{
-                  fontSize: 18,
+                  fontSize: 16,
                   color: 'text.primary',
                   sx: { opacity: 0.6 },
                 }}
@@ -265,7 +263,7 @@ export const ProjectDetailsMenu: ProjectDetailsMenuType = ({
               <ListItemText
                 primary={item.label}
                 primaryTypographyProps={{
-                  fontSize: 18,
+                  fontSize: 16,
                   color: selected ? 'primary' : 'text.primary',
                   sx: { opacity: selected ? 1 : 0.6 },
                 }}
@@ -421,7 +419,7 @@ export const Sidebar: SidebarType = ({ open, onToggleSidebar }) => {
         <ListItem component="div">
           {open && (
             <ListItemText
-              sx={{ mt: 4, mb: 2 }}
+              sx={{ mt: 0, mb: 0 }}
               primary={
                 isHome
                   ? 'Projects'


### PR DESCRIPTION
This fixes #581.

It reduces project items' font size to 16px, reduces their left padding to 16px, and removes `white-space: no-wrap` from the sidebar, so large project names are displayed properly, both in the project title and in the sidebar item.

Previously, I thought of ellipsis with some kind of tooltip, but I see no problem with this implementation too. Anyway, I'm open to suggestions.

Additionally, there is no horizontal scroll on the sidebar anymore.

To test this, just add some very large project names, as in the following screenshots:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/968790/180667925-49168c49-07f9-4e78-80cf-58835acc6354.png">

<img width="310" alt="image" src="https://user-images.githubusercontent.com/968790/180667939-6347dd1c-e7de-45cf-b84f-4e086566f246.png">
