### PR TITLE
Fix word break overflow

### DIFF
--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -174,6 +174,7 @@ export const ProjectListMenu: ProjectListMenuType = ({
                   fontSize: 16,
                   color: 'text.primary',
                   sx: { opacity: 0.6 },
+                  style: { wordBreak: 'break-all' },
                 }}
               />
             </ListItemButton>

--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -174,7 +174,7 @@ export const ProjectListMenu: ProjectListMenuType = ({
                   fontSize: 16,
                   color: 'text.primary',
                   sx: { opacity: 0.6 },
-                  style: { wordBreak: 'break-all' },
+                  style: { wordBreak: 'break-word' },
                 }}
               />
             </ListItemButton>

--- a/packages/dashboard/src/project/projectListItem.tsx
+++ b/packages/dashboard/src/project/projectListItem.tsx
@@ -52,7 +52,7 @@ export function ProjectListItem({ project }: ProjectListItemProps) {
                 primary={decodeURIComponent(project.projectId)}
                 primaryTypographyProps={{
                   variant: 'body1',
-                  style: { wordBreak: 'break-all' },
+                  style: { wordBreak: 'break-word' },
                 }}
               />
             </ListItem>

--- a/packages/dashboard/src/project/projectListItem.tsx
+++ b/packages/dashboard/src/project/projectListItem.tsx
@@ -52,6 +52,7 @@ export function ProjectListItem({ project }: ProjectListItemProps) {
                 primary={decodeURIComponent(project.projectId)}
                 primaryTypographyProps={{
                   variant: 'body1',
+                  style: { wordBreak: 'break-all' },
                 }}
               />
             </ListItem>


### PR DESCRIPTION
Fixes an edge case of #608.

It forces `word-wrap: break-all` on sidebar items and dashboard project list item card, to avoid horizontal scroll on very large words. To test it, just add a project with a very long word, or even a long word right before the first row ends.

Note: if you wish I can add a polyfill, but IMHO is not necessary:
https://caniuse.com/?search=word-break

Before:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/968790/180824024-0d6c16db-de1a-46c9-a2f5-2efcfa1b4d9e.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/968790/180823720-617eb1e5-ee18-4630-9dfc-1b9da09443c3.png">


After:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/968790/180824426-39a405d8-75ce-416c-9ee2-845d811b34ae.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/968790/180823797-49d34173-959d-452c-8af4-f3f2b2345beb.png">
