### PR TITLE
Fix upload urls in docker-compose.minio.yml

### DIFF
--- a/docker-compose.azure-blob-storage.yml
+++ b/docker-compose.azure-blob-storage.yml
@@ -26,7 +26,6 @@ services:
       - "1234:1234"
     depends_on:
       - mongo
-      - storage
 
   api:
     image: agoldis/sorry-cypress-api:latest

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -18,7 +18,7 @@ services:
       SCREENSHOTS_DRIVER: '../screenshots/minio.driver'
       MINIO_ACCESS_KEY: 'MW32h3gd6HvjBEgTRx'
       MINIO_SECRET_KEY: 't6NgQWUcEyG2AzaDCVkN6sbWcvDCVkN6sGiZ7'
-      MINIO_ENDPOINT: 'storage'
+      MINIO_ENDPOINT: 'localhost'
       MINIO_URL: 'http://localhost'
       MINIO_PORT: '9000'
       MINIO_USESSL: 'false'
@@ -26,9 +26,9 @@ services:
 
     ports:
       - 1234:1234
+      - 9000:9000
     depends_on:
       - mongo
-      - storage
 
   api:
     image: agoldis/sorry-cypress-api:latest
@@ -55,24 +55,23 @@ services:
 
   storage:
     image: minio/minio
-    hostname: 'storage'
+    network_mode: service:director
     environment:
       MINIO_ACCESS_KEY: 'MW32h3gd6HvjBEgTRx'
       MINIO_SECRET_KEY: 't6NgQWUcEyG2AzaDCVkN6sbWcvDCVkN6sGiZ7'
     volumes:
       - ./data/data-minio-cypress:/data
     command: server /data
-    ports:
-      - 9000:9000
 
   createbuckets:
     image: minio/mc
+    network_mode: service:director
     depends_on:
       - storage
     entrypoint: >
       /bin/sh -c "
       sleep 3;
-      /usr/bin/mc config host add myminio http://storage:9000 MW32h3gd6HvjBEgTRx t6NgQWUcEyG2AzaDCVkN6sbWcvDCVkN6sGiZ7;
+      /usr/bin/mc config host add myminio http://localhost:9000 MW32h3gd6HvjBEgTRx t6NgQWUcEyG2AzaDCVkN6sbWcvDCVkN6sGiZ7;
       /usr/bin/mc rm -r --dangerous --force myminio/sorry-cypress;
       /usr/bin/mc mb myminio/sorry-cypress;
       /usr/bin/mc policy set download myminio/sorry-cypress;


### PR DESCRIPTION
This PR improves the docker-compose.minio.yml by changing the networking in order to allows the signature to correctly work.
Before this PR, the upload url sent back by the director is `"https://storage:9000/..."`. The hostname storage is not resolved to anything outside of Docker, except if you modify your /etc/hosts, so you cannot use this url. Also, you cannot change the hostname to localhost because of the signature.
By changing the networking, the director can communicate with minio using the localhost hostname and sign urls using localhost hostname and send back `"https://localhost:9000/..."` as upload urls, which works !

Also this PR fix a circular dependency in `docker-compose.azure-blob-storage.yml` that prevented the docker-compose file to be run.
