### PR TITLE
feat(apollo): makes optional the enable of the landing page playground

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -454,6 +454,8 @@ Resources:
               Value: sorry-cypress
             - Name: MONGODB_URI
               Value: mongodb://sorry-cypress:sorry-cypress@127.0.0.1:27017
+            - Name: APOLLO_PLAYGROUND
+              Value: false
           DependsOn:
             - ContainerName: director
               Condition: START

--- a/docker-compose.azure-blob-storage.yml
+++ b/docker-compose.azure-blob-storage.yml
@@ -32,6 +32,7 @@ services:
     environment:
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
+      APOLLO_PLAYGROUND: 'false'
     ports:
       - 4000:4000
     depends_on:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -32,6 +32,7 @@ services:
     environment:
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
+      APOLLO_PLAYGROUND: 'false'
     ports:
       - 4000:4000
     depends_on:

--- a/docker-compose.cos.yml
+++ b/docker-compose.cos.yml
@@ -28,6 +28,7 @@ services:
     environment:
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
+      APOLLO_PLAYGROUND: 'false'
     ports:
       - 4000:4000
     depends_on:

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -27,6 +27,7 @@ services:
     environment:
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
+      APOLLO_PLAYGROUND: 'false'
     ports:
       - 4000:4000
     depends_on:

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -35,6 +35,7 @@ services:
     environment:
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
+      APOLLO_PLAYGROUND: 'false'
     ports:
       - 4000:4000
     depends_on:

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -3,3 +3,4 @@ import 'dotenv/config';
 export const HOST = process.env.HOST || '0.0.0.0';
 export const PORT = process.env.PORT || 4000;
 export const PAGE_ITEMS_LIMIT = Number(process.env.PAGE_ITEMS_LIMIT ?? 20);
+export const APOLLO_PLAYGROUND = process.env.APOLLO_PLAYGROUND || 'false';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,9 +6,12 @@ import { format } from 'url';
 import { initMongoNoIndexes, isMongoDBHealthy } from '@sorry-cypress/mongo';
 import stoppable from 'stoppable';
 import { ApolloServer } from 'apollo-server-express';
-import { ApolloServerPluginLandingPageGraphQLPlayground } from 'apollo-server-core';
+import {
+  ApolloServerPluginLandingPageGraphQLPlayground,
+  ApolloServerPluginLandingPageDisabled,
+} from 'apollo-server-core';
 import express from 'express';
-import { HOST, PORT } from './config';
+import { HOST, PORT, APOLLO_PLAYGROUND } from './config';
 import { InstancesAPI } from './datasources/instances';
 import { ProjectsAPI } from './datasources/projects';
 import { RunsAPI } from './datasources/runs';
@@ -34,7 +37,11 @@ async function start() {
     resolvers,
     dataSources: () => dataSources,
     introspection: true,
-    plugins: [ApolloServerPluginLandingPageGraphQLPlayground()],
+    plugins: [
+      APOLLO_PLAYGROUND === 'false'
+        ? ApolloServerPluginLandingPageDisabled()
+        : ApolloServerPluginLandingPageGraphQLPlayground(),
+    ],
   });
 
   await apolloServer.start();


### PR DESCRIPTION
I don't see it as wise to enable Apollo Server's playground by default. Using `ApolloServerPluginLandingPageDisabled` we could parameterize the activation of the landing page.

```
const apolloServer = new ApolloServer({
    typeDefs,
    resolvers,
    dataSources: () => dataSources,
    introspection: true,
    plugins: [
      APOLLO_PLAYGROUND === 'false'
        ? ApolloServerPluginLandingPageDisabled()
        : ApolloServerPluginLandingPageGraphQLPlayground(),
    ],
  });
```

With APOLLO_PLAYGROUND set on `false`
```
api:
    build:
      dockerfile: packages/api/Dockerfile
      context: .
    image: agoldis/sorry-cypress-api:${VERSION:-latest}
    environment:
      MONGODB_URI: 'mongodb://mongo:27017'
      MONGODB_DATABASE: 'sorry-cypress'
      APOLLO_PLAYGROUND: 'false'
    ports:
      - 4000:4000
    depends_on:
      - mongo
```
![Screenshot 2022-08-13 at 10 55 11](https://user-images.githubusercontent.com/6388707/184476697-91c649cd-2703-439e-88a1-781223b08920.png)



With APOLLO_PLAYGROUND set on `true`
```
api:
    build:
      dockerfile: packages/api/Dockerfile
      context: .
    image: agoldis/sorry-cypress-api:${VERSION:-latest}
    environment:
      MONGODB_URI: 'mongodb://mongo:27017'
      MONGODB_DATABASE: 'sorry-cypress'
      APOLLO_PLAYGROUND: 'true'
    ports:
      - 4000:4000
    depends_on:
      - mongo
```
![Screenshot 2022-08-13 at 10 56 18](https://user-images.githubusercontent.com/6388707/184476709-f2ed4599-ecd2-4701-b555-0ce7caaefbf7.png)
