### PR TITLE
Fixed issue where director saves the gitlab_ci_token in remoteOrigin

### DIFF
--- a/packages/director/src/execution/__tests__/in-memory.test.ts
+++ b/packages/director/src/execution/__tests__/in-memory.test.ts
@@ -1,34 +1,63 @@
-import {driver} from "@sorry-cypress/director/execution/in-memory";
-import {CreateRunParameters} from "@sorry-cypress/common";
+import { CreateRunParameters } from '@sorry-cypress/common';
+import { driver } from '@sorry-cypress/director/execution/in-memory';
 
-const ALL_SPECS = ['one.spec.ts', 'two.spec.ts', 'three.spec.ts']
+const ALL_SPECS = ['one.spec.ts', 'two.spec.ts', 'three.spec.ts'];
 
 it('should report the correct number of claimed specs as they are picked up', async () => {
-    const createRunParams = makeCreateRunParameters(ALL_SPECS)
-    const { groupId, machineId, runId } = await driver.createRun(createRunParams)
-    const nextTaskRequest = { groupId, machineId, runId, cypressVersion: '10.3.0' }
-    const firstResponse = await driver.getNextTask(nextTaskRequest)
-    expect(firstResponse.claimedInstances).toBe(1)
-    expect(firstResponse.totalInstances).toBe(3)
+  const createRunParams = makeCreateRunParameters(ALL_SPECS);
+  const { groupId, machineId, runId } = await driver.createRun(createRunParams);
+  const nextTaskRequest = {
+    groupId,
+    machineId,
+    runId,
+    cypressVersion: '10.3.0',
+  };
+  const firstResponse = await driver.getNextTask(nextTaskRequest);
+  expect(firstResponse.claimedInstances).toBe(1);
+  expect(firstResponse.totalInstances).toBe(3);
 
-    const secondResponse = await driver.getNextTask(nextTaskRequest)
-    expect(secondResponse.claimedInstances).toBe(2)
+  const secondResponse = await driver.getNextTask(nextTaskRequest);
+  expect(secondResponse.claimedInstances).toBe(2);
 
-    const thirdResponse = await driver.getNextTask(nextTaskRequest)
-    expect(thirdResponse.claimedInstances).toBe(3)
-})
+  const thirdResponse = await driver.getNextTask(nextTaskRequest);
+  expect(thirdResponse.claimedInstances).toBe(3);
+});
 
-const makeCreateRunParameters = (specs: string[]): CreateRunParameters => ({
-    ciBuildId: 'buildId',
-    commit: { sha: '1234' },
+it('should remove gitlab_ci_token from remoteOrigin', async () => {
+  const createRunParams = {
+    ciBuildId: '1',
+    commit: {
+      sha: '1234',
+      remoteOrigin: 'https://gitlab-ci-token:token-to-remove@gitlab.com',
+    },
     projectId: 'myProject',
-    specs,
+    specs: ['one.spec.ts'],
     ci: {
-        params: { ciBuildId: 'buildId' },
-        provider: 'provider',
+      params: { ciBuildId: 'buildId' },
+      provider: 'provider',
     },
     platform: {
-        osName: 'ubuntu',
-        osVersion: '20.04',
+      osName: 'ubuntu',
+      osVersion: '20.04',
     },
-})
+  };
+  const { runId } = await driver.createRun(createRunParams);
+  const run = await driver.getRunById(runId);
+
+  expect(run.meta.commit.remoteOrigin).toEqual('gitlab.com');
+});
+
+const makeCreateRunParameters = (specs: string[]): CreateRunParameters => ({
+  ciBuildId: 'buildId',
+  commit: { sha: '1234' },
+  projectId: 'myProject',
+  specs,
+  ci: {
+    params: { ciBuildId: 'buildId' },
+    provider: 'provider',
+  },
+  platform: {
+    osName: 'ubuntu',
+    osVersion: '20.04',
+  },
+});

--- a/packages/director/src/execution/in-memory.ts
+++ b/packages/director/src/execution/in-memory.ts
@@ -102,6 +102,8 @@ const createRun: ExecutionDriver['createRun'] = async (
     );
   }
 
+  params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[1];
+
   // @ts-ignore
   runs[runId] = {
     runId,

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -73,6 +73,8 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
     }
     const specs = params.specs.map(enhaceSpecForThisRun);
 
+    params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[0];
+
     await storageCreateRun({
       runId,
       cypressVersion: params.cypressVersion,


### PR DESCRIPTION
Fixes #625

[Successfull CI run](https://github.com/bjartur20/sorry-cypress/actions/runs/2868228819)

The director was saving the gitlab_ci_token with the remoteOrigin when running tests in GitlabCI.
This fix removes the gitlab_ci_token from the remoteOrigin parameter, ensuring that only the remoteOrigin is included in the URL.

Also wrote a test for this for in-memory execution.

Please let me know if this should be fixed in any other way :)

For bug fixes:

- [x] Add a reference to the original issue
- [x] Add a test and / or some kind of instructions to verify the fix
