### PR TITLE
Fix wrong indx for remote origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     }
   },
   "devDependencies": {
-    "@types/jest": "^28.1.7",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     }
   },
   "devDependencies": {
+    "@types/jest": "^28.1.7",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.7.0",

--- a/packages/director/package.json
+++ b/packages/director/package.json
@@ -62,6 +62,7 @@
     "@types/node": "^14.11.2",
     "@types/semver": "^7.3.8",
     "@types/uuid": "^3.4.5",
+    "@types/jest": "^27.4.7",
     "babel-plugin-module-resolver": "^4.0.0",
     "jest": "^27.4.7",
     "npm-run-all": "^4.1.5",

--- a/packages/director/src/execution/__tests__/in-memory.test.ts
+++ b/packages/director/src/execution/__tests__/in-memory.test.ts
@@ -1,11 +1,22 @@
-import { CreateRunParameters } from '@sorry-cypress/common';
 import { driver } from '@sorry-cypress/director/execution/in-memory';
 
 const ALL_SPECS = ['one.spec.ts', 'two.spec.ts', 'three.spec.ts'];
 
 it('should report the correct number of claimed specs as they are picked up', async () => {
-  const createRunParams = makeCreateRunParameters(ALL_SPECS);
-  const { groupId, machineId, runId } = await driver.createRun(createRunParams);
+  const { groupId, machineId, runId } = await driver.createRun({
+    ciBuildId: 'buildId',
+    commit: { sha: '1234' },
+    projectId: 'myProject',
+    specs: ALL_SPECS,
+    ci: {
+      params: { ciBuildId: 'buildId' },
+      provider: 'provider',
+    },
+    platform: {
+      osName: 'ubuntu',
+      osVersion: '20.04',
+    },
+  });
   const nextTaskRequest = {
     groupId,
     machineId,
@@ -24,7 +35,7 @@ it('should report the correct number of claimed specs as they are picked up', as
 });
 
 it('should remove gitlab_ci_token from remoteOrigin', async () => {
-  const createRunParams = {
+  const { runId } = await driver.createRun({
     ciBuildId: '1',
     commit: {
       sha: '1234',
@@ -40,24 +51,9 @@ it('should remove gitlab_ci_token from remoteOrigin', async () => {
       osName: 'ubuntu',
       osVersion: '20.04',
     },
-  };
-  const { runId } = await driver.createRun(createRunParams);
+  });
+
   const run = await driver.getRunById(runId);
 
-  expect(run.meta.commit.remoteOrigin).toEqual('gitlab.com');
-});
-
-const makeCreateRunParameters = (specs: string[]): CreateRunParameters => ({
-  ciBuildId: 'buildId',
-  commit: { sha: '1234' },
-  projectId: 'myProject',
-  specs,
-  ci: {
-    params: { ciBuildId: 'buildId' },
-    provider: 'provider',
-  },
-  platform: {
-    osName: 'ubuntu',
-    osVersion: '20.04',
-  },
+  expect(run?.meta.commit.remoteOrigin).toEqual('gitlab.com');
 });

--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -1,0 +1,63 @@
+import { CreateRunParameters, Run } from '@sorry-cypress/common';
+import { driver } from '@sorry-cypress/director/execution/mongo/driver';
+
+const makeCreateRunParameters = (): CreateRunParameters => ({
+  ciBuildId: 'buildId',
+  commit: {
+    sha: '1234',
+    remoteOrigin: 'https://gitlab-ci-token:token-to-remove@gitlab.com',
+  },
+  projectId: 'myProject',
+  specs: ['one.spec.ts'],
+  ci: {
+    params: { ciBuildId: 'buildId' },
+    provider: 'provider',
+  },
+  platform: {
+    osName: 'ubuntu',
+    osVersion: '20.04',
+  },
+});
+
+const mockInsertOneRun = jest.fn(() => {
+  return {
+    ops: [
+      {
+        runId: '123',
+        createdAt: '123',
+      },
+    ],
+  };
+});
+
+jest.mock('@sorry-cypress/mongo', () => {
+  return {
+    Collection: {
+      project: jest.fn(() => {
+        return {
+          findOne: jest.fn(),
+          insertOne: jest.fn(),
+        };
+      }),
+      run: jest.fn(() => {
+        return {
+          insertOne: mockInsertOneRun,
+        };
+      }),
+    },
+    runTimeoutModel: {
+      createRunTimeout: () => {},
+    },
+  };
+});
+
+describe('runs', () => {
+  it('removes gitlab_ci_token from remoteOrigin', async () => {
+    const createRunParams = makeCreateRunParameters();
+    await driver.createRun(createRunParams);
+
+    expect(
+      (mockInsertOneRun.mock.calls[0][0] as Run).meta.commit.remoteOrigin
+    ).toEqual('gitlab.com');
+  });
+});

--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -1,23 +1,5 @@
-import { CreateRunParameters, Run } from '@sorry-cypress/common';
+import { Run } from '@sorry-cypress/common';
 import { driver } from '@sorry-cypress/director/execution/mongo/driver';
-
-const makeCreateRunParameters = (): CreateRunParameters => ({
-  ciBuildId: 'buildId',
-  commit: {
-    sha: '1234',
-    remoteOrigin: 'https://gitlab-ci-token:token-to-remove@gitlab.com',
-  },
-  projectId: 'myProject',
-  specs: ['one.spec.ts'],
-  ci: {
-    params: { ciBuildId: 'buildId' },
-    provider: 'provider',
-  },
-  platform: {
-    osName: 'ubuntu',
-    osVersion: '20.04',
-  },
-});
 
 const mockInsertOneRun = jest.fn(() => {
   return {
@@ -30,7 +12,7 @@ const mockInsertOneRun = jest.fn(() => {
   };
 });
 
-jest.mock('@sorry-cypress/mongo/dist', () => {
+jest.mock('@sorry-cypress/mongo', () => {
   return {
     Collection: {
       project: jest.fn(() => {
@@ -53,11 +35,26 @@ jest.mock('@sorry-cypress/mongo/dist', () => {
 
 describe('runs', () => {
   it('removes gitlab_ci_token from remoteOrigin', async () => {
-    const createRunParams = makeCreateRunParameters();
-    await driver.createRun(createRunParams);
+    await driver.createRun({
+      ciBuildId: 'buildId',
+      commit: {
+        sha: '1234',
+        remoteOrigin: 'https://gitlab-ci-token:token-to-remove@gitlab.com',
+      },
+      projectId: 'myProject',
+      specs: ['one.spec.ts'],
+      ci: {
+        params: { ciBuildId: 'buildId' },
+        provider: 'provider',
+      },
+      platform: {
+        osName: 'ubuntu',
+        osVersion: '20.04',
+      },
+    });
 
     expect(
       (mockInsertOneRun.mock.calls[0][0] as Run).meta.commit.remoteOrigin
-    ).toEqual('gitlab.com');
+    ).toBe('gitlab.com');
   });
 });

--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -12,26 +12,30 @@ const mockInsertOneRun = jest.fn(() => {
   };
 });
 
-jest.mock('@sorry-cypress/mongo', () => {
-  return {
-    Collection: {
-      project: jest.fn(() => {
-        return {
-          findOne: jest.fn(),
-          insertOne: jest.fn(),
-        };
-      }),
-      run: jest.fn(() => {
-        return {
-          insertOne: mockInsertOneRun,
-        };
-      }),
-    },
-    runTimeoutModel: {
-      createRunTimeout: () => {},
-    },
-  };
-});
+jest.mock(
+  '@sorry-cypress/mongo',
+  () => {
+    return {
+      Collection: {
+        project: jest.fn(() => {
+          return {
+            findOne: jest.fn(),
+            insertOne: jest.fn(),
+          };
+        }),
+        run: jest.fn(() => {
+          return {
+            insertOne: mockInsertOneRun,
+          };
+        }),
+      },
+      runTimeoutModel: {
+        createRunTimeout: () => {},
+      },
+    };
+  },
+  { virtual: true }
+);
 
 describe('runs', () => {
   it('removes gitlab_ci_token from remoteOrigin', async () => {

--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -30,7 +30,7 @@ const mockInsertOneRun = jest.fn(() => {
   };
 });
 
-jest.mock('@sorry-cypress/mongo', () => {
+jest.mock('@sorry-cypress/mongo/dist', () => {
   return {
     Collection: {
       project: jest.fn(() => {

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -73,7 +73,7 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
     }
     const specs = params.specs.map(enhaceSpecForThisRun);
 
-    params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[0];
+    params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[1];
 
     await storageCreateRun({
       runId,


### PR DESCRIPTION
Related issue: #625 

[Successfull CI run](https://github.com/bjartur20/sorry-cypress/runs/7879964604)

I used the wrong index to access the url for remoteOrigin in the mongo driver. This PR fixes that issue and adds a test for it.

- [x] Add a reference to the original issue
- [x] Add a test and / or some kind of instructions to verify the fix
