### PR TITLE
now uses URL to parse remoteOrigin

### DIFF
--- a/packages/director/src/execution/__tests__/in-memory.test.ts
+++ b/packages/director/src/execution/__tests__/in-memory.test.ts
@@ -55,5 +55,5 @@ it('should remove gitlab_ci_token from remoteOrigin', async () => {
 
   const run = await driver.getRunById(runId);
 
-  expect(run?.meta.commit.remoteOrigin).toEqual('gitlab.com');
+  expect(run?.meta.commit.remoteOrigin).toEqual('https://gitlab.com');
 });

--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -59,6 +59,6 @@ describe('runs', () => {
 
     expect(
       (mockInsertOneRun.mock.calls[0][0] as Run).meta.commit.remoteOrigin
-    ).toBe('gitlab.com');
+    ).toBe('https://gitlab.com');
   });
 });

--- a/packages/director/src/execution/in-memory.ts
+++ b/packages/director/src/execution/in-memory.ts
@@ -32,6 +32,7 @@ import {
   getClaimedSpecs,
   getFirstUnclaimedSpec,
   getNewSpecsInGroup,
+  getRemoteOrigin,
   getSpecsForGroup,
 } from './utils';
 
@@ -102,7 +103,7 @@ const createRun: ExecutionDriver['createRun'] = async (
     );
   }
 
-  params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[1];
+  params.commit.remoteOrigin = getRemoteOrigin(params.commit.remoteOrigin);
 
   // @ts-ignore
   runs[runId] = {

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -30,6 +30,7 @@ import {
   getClaimedSpecs,
   getFirstUnclaimedSpec,
   getNewSpecsInGroup,
+  getRemoteOrigin,
   getSpecsForGroup,
 } from '../../utils';
 import { createInstance } from '../instances/instance.controller';
@@ -53,7 +54,7 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
   const groupId = params.group ?? generateGroupId(params.platform, ciBuildId);
 
   const machineId = generateUUID();
-  const enhaceSpecForThisRun = enhanceSpec(groupId);
+  const enhanceSpecForThisRun = enhanceSpec(groupId);
 
   const response: CreateRunResponse = {
     groupId,
@@ -71,9 +72,9 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
         getCreateProjectValue(params.projectId, INACTIVITY_TIMEOUT_SECONDS)
       );
     }
-    const specs = params.specs.map(enhaceSpecForThisRun);
+    const specs = params.specs.map(enhanceSpecForThisRun);
 
-    params.commit.remoteOrigin = params.commit.remoteOrigin?.split('@')[1];
+    params.commit.remoteOrigin = getRemoteOrigin(params.commit.remoteOrigin);
 
     await storageCreateRun({
       runId,

--- a/packages/director/src/execution/utils.ts
+++ b/packages/director/src/execution/utils.ts
@@ -31,3 +31,9 @@ export const enhanceSpec = (groupId: string) => (spec: string): RunSpec => ({
   completedAt: null,
   groupId,
 });
+
+export const getRemoteOrigin = (
+  remoteOrigin: string | undefined
+): string | undefined => {
+  if (remoteOrigin) return new URL(remoteOrigin).origin;
+};


### PR DESCRIPTION
Related issue: #625

[Successfull CI run](https://github.com/bjartur20/sorry-cypress/actions/runs/2882079533)

- Better parsing of the remoteOrigin for a run using URL().
- Fixed typo in enhaceSpecForThisRun.
