### PR TITLE
Fixed typing error and added typechecks to ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Run lint
         run: yarn lint
 
+      - name: Type check director
+        run: yarn workspace @sorry-cypress/director build:types
+
+      - name: Type check api
+        run: yarn workspace @sorry-cypress/api build:types
+
+      - name: Type check dashboard
+        run: yarn workspace @sorry-cypress/dashboard type-check
+
       - name: Build common package
         run: yarn workspace @sorry-cypress/common build
 

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./src/**/*"],
   "exclude": ["./src/**/__tests__/*", "node_modules", "dist"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "typeRoots": ["./src/", "./node_modules/@types"]
   }
 }

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -138,7 +138,7 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
       await addNewGroupToRun(
         runId,
         groupId,
-        newSpecs.map(enhaceSpecForThisRun)
+        newSpecs.map(enhanceSpecForThisRun)
       );
 
       return response;


### PR DESCRIPTION
Related issue: #625

[Successfull CI run](https://github.com/bjartur20/sorry-cypress/actions/runs/2888611236)

- Fixed types bug in mongo controller.
- Added typechecking to test job in workflow.

Sorry about the frequent PRs, hoping this is the last one for now 😅 