### PR TITLE
Correct parsing of remoteOrigin url

### DIFF
--- a/packages/director/src/execution/__tests__/mongo.test.ts
+++ b/packages/director/src/execution/__tests__/mongo.test.ts
@@ -38,27 +38,66 @@ jest.mock(
 );
 
 describe('runs', () => {
-  it('removes gitlab_ci_token from remoteOrigin', async () => {
-    await driver.createRun({
-      ciBuildId: 'buildId',
-      commit: {
-        sha: '1234',
-        remoteOrigin: 'https://gitlab-ci-token:token-to-remove@gitlab.com',
-      },
-      projectId: 'myProject',
-      specs: ['one.spec.ts'],
-      ci: {
-        params: { ciBuildId: 'buildId' },
-        provider: 'provider',
-      },
-      platform: {
-        osName: 'ubuntu',
-        osVersion: '20.04',
-      },
-    });
+  afterEach(() => {
+    mockInsertOneRun.mockClear();
+  });
 
-    expect(
-      (mockInsertOneRun.mock.calls[0][0] as Run).meta.commit.remoteOrigin
-    ).toBe('https://gitlab.com');
+  [
+    {
+      originType: 'GitLab CI',
+      remoteOrigin:
+        'https://gitlab-ci-token:token-to-remove@gitlab.com:group/project.git',
+      expected: 'https://gitlab.com/group/project.git',
+    },
+    {
+      originType: 'GitLab CI subdomain',
+      remoteOrigin:
+        'https://gitlab-ci-token:token-to-remove@gitlab.company.com:group/project.git',
+      expected: 'https://gitlab.company.com/group/project.git',
+    },
+    {
+      originType: 'GitLab',
+      remoteOrigin: 'git@gitlab.com:group/project.git',
+      expected: 'https://gitlab.com/group/project.git',
+    },
+    {
+      originType: 'GitLab subdomain',
+      remoteOrigin: 'git@gitlab.company.com:group/project.git',
+      expected: 'https://gitlab.company.com/group/project.git',
+    },
+    {
+      originType: 'GitHub',
+      remoteOrigin: 'git@github.com:group/project.git',
+      expected: 'https://github.com/group/project.git',
+    },
+    {
+      originType: 'BitBucket',
+      remoteOrigin: 'git@bitbucket.org:group/project.git',
+      expected: 'https://bitbucket.org/group/project.git',
+    },
+  ].forEach(({ originType, remoteOrigin, expected }) => {
+    it(`sets the correct remoteOrigin for ${originType}`, async () => {
+      await driver.createRun({
+        ciBuildId: 'buildId',
+        commit: {
+          sha: '1234',
+          remoteOrigin,
+        },
+        projectId: 'myProject',
+        specs: ['one.spec.ts'],
+        ci: {
+          params: { ciBuildId: 'buildId' },
+          provider: 'provider',
+        },
+        platform: {
+          osName: 'ubuntu',
+          osVersion: '20.04',
+        },
+      });
+
+      expect(
+        (mockInsertOneRun.mock.calls[0][0] as Run).meta.commit.remoteOrigin
+      ).toBe(expected);
+    });
   });
 });

--- a/packages/director/src/execution/utils.ts
+++ b/packages/director/src/execution/utils.ts
@@ -35,5 +35,7 @@ export const enhanceSpec = (groupId: string) => (spec: string): RunSpec => ({
 export const getRemoteOrigin = (
   remoteOrigin: string | undefined
 ): string | undefined => {
-  if (remoteOrigin) return new URL(remoteOrigin).origin;
+  if (!remoteOrigin) return;
+
+  return 'https://' + remoteOrigin.split('@')[1].replace(':', '/');
 };


### PR DESCRIPTION
Resolves #634

Also adds testing for GitLab, Github, and BitBucket of the parsing function.

[CI run](https://github.com/bjartur20/sorry-cypress/actions/runs/2939227511)

For bug fixes:
- [x] Add a reference to the original issue
- [x] Add a test and / or some kind of instructions to verify the fix
