### PR TITLE
chore: update vm2 to 3.9.11

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13790,9 +13790,9 @@ vizion@~2.2.1:
     js-git "^0.7.8"
 
 vm2@^3.9.8:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.10.tgz#c66543096b5c44c8861a6465805c23c7cc996a44"
-  integrity sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==
+  version "3.9.11"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
+  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
CVE-2022-36067

https://nvd.nist.gov/vuln/detail/CVE-2022-36067
https://github.com/patriksimek/vm2/issues/467


For bug fixes:

- [X] Add a reference to the original issue
- [ ] Add a test and / or some kind of instructions to verify the fix

---

For new features:

- [ ] It's better to first discuss features proposal in [Discussions](https://github.com/sorry-cypress/sorry-cypress/discussions) or [Slack](https://sorry-cypress.slack.com/join/shared_invite/zt-eis1h6jl-tJELaD7q9UGEhMP8WHJOaw#/)
- [ ] Describe the use-case in details
- [ ] Ensure the solution is backwards-compatible
- [ ] Test it. Submit screenshots / outputs / tests together with the PR.
