### PR TITLE
fix: director returning 500 using gitlab job retries

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -427,7 +427,7 @@ Resources:
               Value: ../execution/mongo/driver
             - Name: SCREENSHOTS_DRIVER
               Value: ../screenshots/s3.driver
-            - Name: GITLAB_JOB_RETIRES
+            - Name: GITLAB_JOB_RETRIES
               Value: false
             - Name: MONGODB_DATABASE
               Value: sorry-cypress

--- a/packages/director/src/execution/mongo/runs/run.controller.ts
+++ b/packages/director/src/execution/mongo/runs/run.controller.ts
@@ -45,7 +45,7 @@ import {
   createRun as storageCreateRun,
   getNewGroupTemplate,
   getRunById,
-  resetSpecs,
+  resetFailedSpecs,
   setRunCompleted,
   setSpecClaimed,
   setSpecCompleted,
@@ -143,7 +143,7 @@ export const createRun: ExecutionDriver['createRun'] = async (params) => {
         } else {
           // Retry job
           const failedSpecs = getFailedSpecs(run, groupId);
-          await resetSpecs(run, groupId, failedSpecs);
+          await resetFailedSpecs(run, groupId, failedSpecs);
         }
       }
 

--- a/packages/director/src/execution/mongo/runs/run.model.ts
+++ b/packages/director/src/execution/mongo/runs/run.model.ts
@@ -279,26 +279,26 @@ export const resetSpecs = async (
         [`${groupPath}.instances.claimed`]: -1,
         [`${groupPath}.instances.complete`]: -1,
         [`${groupPath}.instances.failures`]: -1,
-        [`${groupPath}.tests.overall`]: -specs.reduce(
-          (t, s) => t + s.results!.stats.tests,
-          0
-        ),
-        [`${groupPath}.tests.passes`]: -specs.reduce(
-          (t, s) => t + s.results!.stats.passes,
-          0
-        ),
-        [`${groupPath}.tests.failures`]: -specs.reduce(
-          (t, s) => t + s.results!.stats.failures,
-          0
-        ),
-        [`${groupPath}.tests.skipped`]: -specs.reduce(
-          (t, s) => t + s.results!.stats.skipped,
-          0
-        ),
-        [`${groupPath}.tests.pending`]: -specs.reduce(
-          (t, s) => t + s.results!.stats.pending,
-          0
-        ),
+        [`${groupPath}.tests.overall`]: -specs.reduce((t, s) => {
+          if (!s.results) return t + 0;
+          return t + s.results.stats.tests;
+        }, 0),
+        [`${groupPath}.tests.passes`]: -specs.reduce((t, s) => {
+          if (!s.results) return t + 0;
+          return t + s.results.stats.passes;
+        }, 0),
+        [`${groupPath}.tests.failures`]: -specs.reduce((t, s) => {
+          if (!s.results) return t + 0;
+          return t + s.results.stats.failures;
+        }, 0),
+        [`${groupPath}.tests.skipped`]: -specs.reduce((t, s) => {
+          if (!s.results) return t + 0;
+          return t + s.results.stats.skipped;
+        }, 0),
+        [`${groupPath}.tests.pending`]: -specs.reduce((t, s) => {
+          if (!s.results) return t + 0;
+          return t + s.results.stats.pending;
+        }, 0),
       },
     }
   );

--- a/packages/director/src/execution/mongo/runs/run.model.ts
+++ b/packages/director/src/execution/mongo/runs/run.model.ts
@@ -241,7 +241,7 @@ export const setSpecCompleted = async (
   }
 };
 
-export const resetSpecs = async (
+export const resetFailedSpecs = async (
   run: Run,
   groupId: string,
   specs: RunSpec[]
@@ -279,26 +279,26 @@ export const resetSpecs = async (
         [`${groupPath}.instances.claimed`]: -1,
         [`${groupPath}.instances.complete`]: -1,
         [`${groupPath}.instances.failures`]: -1,
-        [`${groupPath}.tests.overall`]: -specs.reduce((t, s) => {
-          if (!s.results) return t + 0;
-          return t + s.results.stats.tests;
-        }, 0),
-        [`${groupPath}.tests.passes`]: -specs.reduce((t, s) => {
-          if (!s.results) return t + 0;
-          return t + s.results.stats.passes;
-        }, 0),
-        [`${groupPath}.tests.failures`]: -specs.reduce((t, s) => {
-          if (!s.results) return t + 0;
-          return t + s.results.stats.failures;
-        }, 0),
-        [`${groupPath}.tests.skipped`]: -specs.reduce((t, s) => {
-          if (!s.results) return t + 0;
-          return t + s.results.stats.skipped;
-        }, 0),
-        [`${groupPath}.tests.pending`]: -specs.reduce((t, s) => {
-          if (!s.results) return t + 0;
-          return t + s.results.stats.pending;
-        }, 0),
+        [`${groupPath}.tests.overall`]: -specs.reduce(
+          (t, s) => t + (s.results?.stats.tests ?? 0),
+          0
+        ),
+        [`${groupPath}.tests.passes`]: -specs.reduce(
+          (t, s) => t + (s.results?.stats.passes ?? 0),
+          0
+        ),
+        [`${groupPath}.tests.failures`]: -specs.reduce(
+          (t, s) => t + (s.results?.stats.failures ?? 0),
+          0
+        ),
+        [`${groupPath}.tests.skipped`]: -specs.reduce(
+          (t, s) => t + (s.results?.stats.skipped ?? 0),
+          0
+        ),
+        [`${groupPath}.tests.pending`]: -specs.reduce(
+          (t, s) => t + (s.results?.stats.pending ?? 0),
+          0
+        ),
       },
     }
   );

--- a/packages/director/src/execution/utils.ts
+++ b/packages/director/src/execution/utils.ts
@@ -10,7 +10,7 @@ export const getFirstUnclaimedSpec = (run: Run, groupId: string) =>
   getSpecsForGroup(run, groupId).find((s) => !s.claimedAt);
 export const getFailedSpecs = (run: Run, groupId: string) =>
   getSpecsForGroup(run, groupId).filter((s) =>
-    s.results ? s.results?.stats.failures + s.results.stats.skipped > 0 : false
+    s.results ? s.results.stats.failures + s.results.stats.skipped > 0 : false
   );
 
 interface GetNewSpecsForGroupParams {

--- a/packages/director/src/execution/utils.ts
+++ b/packages/director/src/execution/utils.ts
@@ -9,8 +9,8 @@ export const getClaimedSpecs = (run: Run, groupId: string) =>
 export const getFirstUnclaimedSpec = (run: Run, groupId: string) =>
   getSpecsForGroup(run, groupId).find((s) => !s.claimedAt);
 export const getFailedSpecs = (run: Run, groupId: string) =>
-  getSpecsForGroup(run, groupId).filter(
-    (s) => s.results && s.results.stats.failures > 0
+  getSpecsForGroup(run, groupId).filter((s) =>
+    s.results ? s.results?.stats.failures + s.results.stats.skipped > 0 : false
   );
 
 interface GetNewSpecsForGroupParams {

--- a/packages/director/src/execution/utils.ts
+++ b/packages/director/src/execution/utils.ts
@@ -9,7 +9,9 @@ export const getClaimedSpecs = (run: Run, groupId: string) =>
 export const getFirstUnclaimedSpec = (run: Run, groupId: string) =>
   getSpecsForGroup(run, groupId).find((s) => !s.claimedAt);
 export const getFailedSpecs = (run: Run, groupId: string) =>
-  getSpecsForGroup(run, groupId).filter((s) => s.results!.stats.failures > 0);
+  getSpecsForGroup(run, groupId).filter(
+    (s) => s.results && s.results.stats.failures > 0
+  );
 
 interface GetNewSpecsForGroupParams {
   run: Run;


### PR DESCRIPTION
Bug reported here on the original [PR](https://github.com/sorry-cypress/sorry-cypress/pull/641#issuecomment-1251988954)

The cause of the bug was as @vinhoe suggested, the getFailedSpecs function was throwing an error when specs had already in reset.

[Bug ticket](https://github.com/sorry-cypress/sorry-cypress/issues/652#issue-1380911426)

