### PR TITLE
changed gitlab_job_retries to general retries

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -427,7 +427,7 @@ Resources:
               Value: ../execution/mongo/driver
             - Name: SCREENSHOTS_DRIVER
               Value: ../screenshots/s3.driver
-            - Name: GITLAB_JOB_RETRIES
+            - Name: TEST_RETRIES
               Value: false
             - Name: MONGODB_DATABASE
               Value: sorry-cypress

--- a/docker-compose.azure-blob-storage.yml
+++ b/docker-compose.azure-blob-storage.yml
@@ -14,7 +14,7 @@ services:
     environment:
       DASHBOARD_URL: http://localhost:8080
       EXECUTION_DRIVER: '../execution/mongo/driver'
-      GITLAB_JOB_RETRIES: 'false'
+      TEST_RETRIES: 'false'
       MONGODB_URI: 'mongodb://mongo:27017'
       MONGODB_DATABASE: 'sorry-cypress'
       SCREENSHOTS_DRIVER: '../screenshots/azure-blob-storage.driver'

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -16,7 +16,7 @@ services:
       MONGODB_DATABASE: 'sorry-cypress'
       EXECUTION_DRIVER: '../execution/mongo/driver'
       SCREENSHOTS_DRIVER: '../screenshots/s3.driver'
-      GITLAB_JOB_RETRIES: 'false'
+      TEST_RETRIES: 'false'
       AWS_ACCESS_KEY_ID: 'key'
       AWS_SECRET_ACCESS_KEY: 'secret'
       S3_BUCKET: sorry-cypress

--- a/docker-compose.cos.yml
+++ b/docker-compose.cos.yml
@@ -14,7 +14,7 @@ services:
       MONGODB_DATABASE: 'sorry-cypress'
       EXECUTION_DRIVER: '../execution/mongo/driver'
       SCREENSHOTS_DRIVER: '../screenshots/cos.driver'
-      GITLAB_JOB_RETRIES: 'false'
+      TEST_RETRIES: 'false'
       COS_ACCESSKEY: 'cos_hmac_access_key'
       COS_SECRETKEY: 'cos_hmac_secret_key'
       COS_REGION: 'cos_region'

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -14,7 +14,7 @@ services:
       MONGODB_DATABASE: 'sorry-cypress'
       EXECUTION_DRIVER: '../execution/mongo/driver'
       SCREENSHOTS_DRIVER: '../screenshots/s3.driver'
-      GITLAB_JOB_RETRIES: 'false'
+      TEST_RETRIES: 'false'
       AWS_ACCESS_KEY_ID: 'key'
       AWS_SECRET_ACCESS_KEY: 'secret'
       S3_BUCKET: sorry-cypress

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -16,7 +16,7 @@ services:
       MONGODB_DATABASE: 'sorry-cypress'
 
       SCREENSHOTS_DRIVER: '../screenshots/minio.driver'
-      GITLAB_JOB_RETRIES: 'false'
+      TEST_RETRIES: 'false'
       MINIO_ACCESS_KEY: 'MW32h3gd6HvjBEgTRx'
       MINIO_SECRET_KEY: 't6NgQWUcEyG2AzaDCVkN6sbWcvDCVkN6sGiZ7'
       MINIO_ENDPOINT: 'localhost'

--- a/packages/director/src/config.ts
+++ b/packages/director/src/config.ts
@@ -29,4 +29,4 @@ export const INACTIVITY_TIMEOUT_SECONDS = Number(
 
 export const REDIS_URI = process.env.REDIS_URI;
 
-export const GITLAB_JOB_RETRIES = process.env.GITLAB_JOB_RETRIES || 'false';
+export const TEST_RETRIES = process.env.TEST_RETRIES || 'false';


### PR DESCRIPTION

I needed retries in bitbucket so I tried to change `GITLAB_JOB_RETRIES` to a general option so we can use it everywhere. I renamed the flag and I changed two conditions, now it works well in bitbucket too.