### PR TITLE
feat: Add Fullscreen button to video player

### DIFF
--- a/packages/dashboard/src/components/ui/player.tsx
+++ b/packages/dashboard/src/components/ui/player.tsx
@@ -3,6 +3,7 @@ import {
   FastRewindRounded,
   PauseRounded,
   PlayArrowRounded,
+  Fullscreen,
 } from '@mui/icons-material';
 import {
   alpha,
@@ -151,40 +152,60 @@ export const Player: PlayerComponent = (props) => {
         sx={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
+          justifyContent: 'space-between',
           mt: -1,
         }}
       >
-        <IconButton
-          aria-label="fast rewind"
-          onClick={() =>
-            playerRef.current &&
-            playerRef.current.seekTo(
-              playedSeconds - 2 < 0 ? 0 : playedSeconds - 2
-            )
-          }
-        >
-          <FastRewindRounded fontSize="large" />
-        </IconButton>
-        <IconButton
-          aria-label={playing ? 'play' : 'pause'}
-          onClick={() => setPlaying(!playing)}
-        >
-          {playing ? (
-            <PauseRounded sx={{ fontSize: '3rem' }} />
-          ) : (
-            <PlayArrowRounded sx={{ fontSize: '3rem' }} />
-          )}
-        </IconButton>
-        <IconButton
-          aria-label="fast forward"
-          onClick={() => {
-            playerRef.current &&
-              playedSeconds + 2 < duration &&
-              playerRef.current.seekTo(playedSeconds + 2);
+        <div></div>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
-          <FastForwardRounded fontSize="large" />
+          <IconButton
+            aria-label="fast rewind"
+            onClick={() =>
+              playerRef.current &&
+              playerRef.current.seekTo(
+                playedSeconds - 2 < 0 ? 0 : playedSeconds - 2
+              )
+            }
+          >
+            <FastRewindRounded fontSize="large" />
+          </IconButton>
+          <IconButton
+            aria-label={playing ? 'play' : 'pause'}
+            onClick={() => setPlaying(!playing)}
+          >
+            {playing ? (
+              <PauseRounded sx={{ fontSize: '3rem' }} />
+            ) : (
+              <PlayArrowRounded sx={{ fontSize: '3rem' }} />
+            )}
+          </IconButton>
+          <IconButton
+            aria-label="fast forward"
+            onClick={() => {
+              playerRef.current &&
+                playedSeconds + 2 < duration &&
+                playerRef.current.seekTo(playedSeconds + 2);
+            }}
+          >
+            <FastForwardRounded fontSize="large" />
+          </IconButton>
+        </Box>
+        <IconButton
+          aria-label="fullscreen"
+          onClick={() =>
+            playerRef.current &&
+            playerRef.current.getInternalPlayer().requestFullscreen &&
+            playerRef.current.getInternalPlayer().requestFullscreen()
+          }
+        >
+          <Fullscreen fontSize="small" />
         </IconButton>
       </Box>
     </Box>


### PR DESCRIPTION
- [x] It's better to first discuss features proposal: https://github.com/sorry-cypress/sorry-cypress/discussions/662
- [x] Describe the use-case in details
- [x] Ensure the solution is backwards-compatible
- [x] Test it. Submit screenshots / outputs / tests together with the PR.

## Use Case

When viewing the video, on some screens the side of the video player is quite small. To full screen the video, the user must download the video to watch on their own player, or enable browser video controls on each video they want to view, and then select full screen from that. This new button allows user to full screen the video without any work-around

## Screenshots:

![image](https://user-images.githubusercontent.com/9289772/198017440-214a933e-61bf-4821-9558-e062d0ba176b.png)

