### PR TITLE
build(dashboard): switch to nginx unprivileged docker

### DIFF
--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install --frozen-lockfile
 RUN yarn workspace @sorry-cypress/common build
 RUN yarn workspace @sorry-cypress/dashboard build
 
-FROM nginx:1.22-alpine
+FROM nginxinc/nginx-unprivileged:1.23-alpine
 WORKDIR /usr/share/nginx/html
 COPY packages/dashboard/nginx/default.conf.template /etc/nginx/templates/default.conf.template
 COPY packages/dashboard/server/static .


### PR DESCRIPTION
fixes #690

how I tested:
-  created a new docker using scripts/release-dockerhub.sh
- edited docker-compose.minio.yml to use newly created image
- docker-compose -f docker-compose.minio.yml up
- dashboard just running fine: 
![image](https://user-images.githubusercontent.com/4358455/202911775-7f7359b8-e77a-4f1d-8dce-694ada14bd7b.png)


For bug fixes:

- [ ] Add a reference to the original issue
- [x] Add a test and / or some kind of instructions to verify the fix

---

For new features:

- [ ] It's better to first discuss features proposal in [Discussions](https://github.com/sorry-cypress/sorry-cypress/discussions) or [Slack](https://sorry-cypress.slack.com/join/shared_invite/zt-eis1h6jl-tJELaD7q9UGEhMP8WHJOaw#/)
- [ ] Describe the use-case in details
- [ ] Ensure the solution is backwards-compatible
- [x] Test it. Submit screenshots / outputs / tests together with the PR.
