### PR TITLE
Adjust github reporter tests and support enterprise URL

### DIFF
--- a/packages/common/src/hook/github.ts
+++ b/packages/common/src/hook/github.ts
@@ -1,23 +1,19 @@
+const GITHUB_COM_DOMAIN = 'github.com';
+
 export const getGithubConfiguration = (url: string) => {
   const [githubProtocol, restOfGithubUrl] = url.split('://');
   const [githubDomain, githubProject, githubRepo] = restOfGithubUrl.split('/');
+  const isEnterpriseUrl = githubDomain !== GITHUB_COM_DOMAIN;
+  const enterpriseUrl = isEnterpriseUrl
+    ? `${githubProtocol}://${githubDomain}/api/v3`
+    : undefined;
 
-  return { githubDomain, githubProject, githubRepo, githubProtocol };
-};
-
-export const getGithubStatusUrl = (url: string, sha: string) => {
-  const GITHUB_COM_DOMAIN = 'github.com';
-  const GITHUB_COM_ENDPOINT = 'api.github.com';
-
-  const {
+  return {
     githubDomain,
     githubProject,
     githubRepo,
     githubProtocol,
-  } = getGithubConfiguration(url);
-  const githubEndpoint =
-    githubDomain === GITHUB_COM_DOMAIN
-      ? GITHUB_COM_ENDPOINT
-      : `${githubDomain}/api/v3`;
-  return `${githubProtocol}://${githubEndpoint}/repos/${githubProject}/${githubRepo}/statuses/${sha}`;
+    isEnterpriseUrl,
+    enterpriseUrl,
+  };
 };

--- a/packages/common/src/hook/types.ts
+++ b/packages/common/src/hook/types.ts
@@ -50,8 +50,8 @@ export type GithubHook = BaseHook & {
   githubToken?: string;
   githubContext?: string;
   githubAppPrivateKey?: string;
-  githubAppId?: number;
-  githubAppInstallationId?: number;
+  githubAppId?: string;
+  githubAppInstallationId?: string;
 };
 
 export type BitBucketHook = BaseHook & {

--- a/packages/dashboard/src/project/hook/validation.ts
+++ b/packages/dashboard/src/project/hook/validation.ts
@@ -1,7 +1,7 @@
 import {
-  ResultFilter,
   getBitbucketBuildUrl,
-  getGithubStatusUrl,
+  getGithubConfiguration,
+  ResultFilter,
 } from '@sorry-cypress/common';
 
 export const bitbucketUrlValidation = (value: string) => {
@@ -15,7 +15,7 @@ export const bitbucketUrlValidation = (value: string) => {
 
 export const githubUrlValidation = (value: string) => {
   try {
-    getGithubStatusUrl(value, 'fake');
+    getGithubConfiguration(value);
     return true;
   } catch (e) {
     return 'Valid Github URL required, e.g. https://github.com/<org>/<repository>.git';

--- a/packages/director/src/lib/hooks/__tests__/fixtures/githubReportStatusRequest.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/githubReportStatusRequest.json
@@ -1,17 +1,6 @@
 {
-  "method": "post",
-  "url": "https://api.github.com/repos/test-company/test-project/statuses/testCommitSha",
-  "auth": {
-    "password": "testGithubToken",
-    "username": "sorry-cypress"
-  },
-  "headers": {
-    "Accept": "application/vnd.github.v3+json"
-  },
-  "data": {
-    "context": "testGithubContext: ciBuildId",
-    "description": "failed:0 skipped:0 passed:1 pending:0 flaky:undefined",
-    "state": "pending",
-    "target_url": "http://localhost:8080/run/testRunId"
-  }
+  "context": "testGithubContext: ciBuildId",
+  "description": "failed:0 skipped:0 passed:1 pending:0 flaky:undefined",
+  "state": "pending",
+  "target_url": "http://localhost:8080/run/testRunId"
 }

--- a/packages/director/src/lib/hooks/reporters/github.ts
+++ b/packages/director/src/lib/hooks/reporters/github.ts
@@ -1,5 +1,4 @@
 import { createAppAuth } from '@octokit/auth-app';
-import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { Octokit } from '@octokit/rest';
 import {
   getGithubConfiguration,
@@ -12,6 +11,8 @@ import {
 import { APP_NAME } from '@sorry-cypress/director/config';
 import { getDashboardRunURL } from '@sorry-cypress/director/lib/urls';
 import { getLogger } from '@sorry-cypress/logger';
+
+type OctokitOptions = ConstructorParameters<typeof Octokit>[0];
 
 type GithubStatusData = {
   state: 'error' | 'failure' | 'pending' | 'success' | undefined;

--- a/packages/director/src/lib/hooks/reporters/github.ts
+++ b/packages/director/src/lib/hooks/reporters/github.ts
@@ -3,7 +3,6 @@ import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { Octokit } from '@octokit/rest';
 import {
   getGithubConfiguration,
-  getGithubStatusUrl,
   GithubHook,
   HookEvent,
   isRunGroupSuccessful,
@@ -98,6 +97,14 @@ export async function reportStatusToGithub(
     return;
   }
 
+  const {
+    githubDomain,
+    githubRepo,
+    githubProject,
+    isEnterpriseUrl,
+    enterpriseUrl,
+  } = getGithubConfiguration(hook.url);
+
   const octokitOptions: OctokitOptions = {
     auth: hook.githubToken,
   };
@@ -111,17 +118,25 @@ export async function reportStatusToGithub(
     };
   }
 
+  if (isEnterpriseUrl) {
+    octokitOptions.baseUrl = enterpriseUrl;
+  }
+
   const octokit = new Octokit(octokitOptions);
 
-  const fullStatusPostUrl = getGithubStatusUrl(hook.url, run.meta.commit.sha);
-  const { githubRepo, githubProject } = getGithubConfiguration(hook.url);
-
   getLogger().log(
-    { fullStatusPostUrl, eventType, ...data },
+    {
+      githubDomain,
+      githubRepo,
+      githubProject,
+      sha: run.meta.commit.sha,
+      eventType,
+      ...data,
+    },
     '[github-reporter] Sending HTTP request to GitHub'
   );
   try {
-    await octokit.rest.repos.createCommitStatus({
+    await octokit.repos.createCommitStatus({
       sha: run.meta.commit.sha,
       owner: githubProject,
       repo: githubRepo,
@@ -133,12 +148,14 @@ export async function reportStatusToGithub(
   } catch (error) {
     getLogger().error(
       {
-        fullStatusPostUrl,
+        githubDomain,
+        githubRepo,
+        githubProject,
         runId: run.runId,
         error: error.toJSON ? error.toJSON() : error,
         resonse: error.response?.data ? error.response.data : null,
       },
-      `[github-reporter] Hook post to ${fullStatusPostUrl} responded with error`
+      `[github-reporter] Hook post to ${githubDomain} responded with error`
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4049,17 +4049,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@4.17.13":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
-  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
-"@types/express@^4.17.12":
+"@types/express@4.17.12", "@types/express@4.17.13", "@types/express@^4.17.12":
   version "4.17.12"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.12.tgz#4bc1bf3cd0cfe6d3f6f2853648b40db7d54de350"
   integrity sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==
@@ -4403,7 +4393,7 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
   integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10":
+"@types/serve-static@*", "@types/serve-static@1.13.10", "@types/serve-static@^1.13.10":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -4780,6 +4770,11 @@ acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^7.1.1:
   version "7.4.1"
@@ -6740,14 +6735,15 @@ define-properties@^1.1.3, define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-degenerator@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-2.2.0.tgz#49e98c11fa0293c5b26edfbb52f15729afcdb254"
-  integrity sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==
+degenerator@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-3.0.2.tgz#6a61fcc42a702d6e50ff6023fe17bff435f68235"
+  integrity sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==
   dependencies:
     ast-types "^0.13.2"
     escodegen "^1.8.1"
     esprima "^4.0.0"
+    vm2 "^3.9.8"
 
 del@^6.0.0:
   version "6.0.0"
@@ -10814,7 +10810,7 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-netmask@^2.0.1:
+netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
@@ -11331,14 +11327,14 @@ pac-proxy-agent@^4.1.0:
     raw-body "^2.2.0"
     socks-proxy-agent "5"
 
-pac-resolver@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd"
-  integrity sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==
+pac-resolver@^4.1.0, pac-resolver@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-5.0.1.tgz#c91efa3a9af9f669104fa2f51102839d01cde8e7"
+  integrity sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==
   dependencies:
-    degenerator "^2.2.0"
+    degenerator "^3.0.2"
     ip "^1.1.5"
-    netmask "^2.0.1"
+    netmask "^2.0.2"
 
 package-json@^6.3.0:
   version "6.5.0"
@@ -14040,6 +14036,14 @@ vizion@~2.2.1:
     git-node-fs "^1.0.0"
     ini "^1.3.5"
     js-git "^0.7.8"
+
+vm2@^3.9.8:
+  version "3.9.11"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
+  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
When switching to octokit, the support for an enterprise URL was not implemented properly. With these changes it is now again possible to use an enterprise URL and the test were adjusted properly.

@agoldis I cherry-picked your commit from #695, I hope that is ok with you. Again sorry for the inconvenience.
