### PR TITLE
feat: Add screenshot zoom in/out on preview functionality

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -50,6 +50,7 @@
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
     "react-hook-form": "^6.15.8",
+    "react-medium-image-zoom": "^5.1.2",
     "react-player": "^2.9.0",
     "react-router": "^6.0.2",
     "react-router-dom": "^6.0.2",

--- a/packages/dashboard/src/testItem/details/common.tsx
+++ b/packages/dashboard/src/testItem/details/common.tsx
@@ -4,6 +4,8 @@ import { Box } from '@mui/system';
 import { ExpandableArea } from '@sorry-cypress/dashboard/components';
 import { InstanceScreeshot } from '@sorry-cypress/dashboard/generated/graphql';
 import React from 'react';
+import Zoom from 'react-medium-image-zoom';
+import 'react-medium-image-zoom/dist/styles.css';
 
 export const TestError = ({
   name,
@@ -46,13 +48,9 @@ export const Screenshot = ({
   if (!screenshot?.screenshotURL) {
     return null;
   }
+
   return (
-    <Box
-      component="a"
-      target="_blank"
-      rel="noopener noreferrer"
-      href={screenshot.screenshotURL}
-    >
+    <Zoom>
       <Box
         component="img"
         src={screenshot.screenshotURL}
@@ -62,6 +60,6 @@ export const Screenshot = ({
           borderRadius: 1,
         }}
       />
-    </Box>
+    </Zoom>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12110,6 +12110,11 @@ react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-medium-image-zoom@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-5.1.2.tgz#ff13b8cf37e3348c36a2fc6deade84912fdad8ce"
+  integrity sha512-Lk9TDqd+vUpQVP77p45jXgh1LGjClLfyLJnTemCfpI+5Zp3X7MX7iGP5VmSdLGXy9mhdlZiByHOyp4Irf4N8vg==
+
 react-player@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.9.0.tgz#ef7fe7073434087565f00ff219824e1e02c4b046"


### PR DESCRIPTION
New feature:

- [x] Discussed here: https://github.com/sorry-cypress/sorry-cypress/issues/519
- [x] Use case: when I click on a screenshot, I should be able to preview & zoom instead of downloading it.
- [x] Backward compatibility is not relevant to this fix (the UI will work with older versions of other packages)
- [x] See [video recording](https://github.com/sorry-cypress/sorry-cypress/issues/519#issuecomment-1327914582) for demo
