### PR TITLE
refactor: cloudformation | graphql schema path

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -476,7 +476,7 @@ Resources:
               awslogs-stream-prefix: ecs
           Environment:
             - Name: GRAPHQL_SCHEMA_URL
-              Value: /api
+              Value: /graphql
             - Name: PORT
               Value: 8080
             - Name: CI_URL


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link [Link](https://github.com/sorry-cypress/gitbook/pull/23)
- [ ] I have added included automated tests
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: [Link](https://github.com/sorry-cypress/sorry-cypress/issues/726)

## Use case

> The current deployment method of AWS Cloudformation does not use the correct uri for GRAPHQL_SCHEMA_URL. The correct path that works is `<sorry-cypress-url>/graphql`. 

## Example
on using `/graphql`, the api responds correctly
> <img width="1034" alt="Screenshot 2023-01-21 at 4 20 40 PM" src="https://user-images.githubusercontent.com/29128958/213863674-c293b40b-ee96-45c7-b05c-ce9747d4224a.png">
