### PR TITLE
Multi Architecture Docker Images

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -7,15 +7,13 @@ COPY packages/logger/ ./packages/logger
 COPY package.json ./
 COPY yarn.lock ./
 COPY tsconfig.json ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 300000
 RUN yarn workspace @sorry-cypress/common build
 RUN yarn workspace @sorry-cypress/mongo build
 RUN yarn workspace @sorry-cypress/logger build
 RUN yarn workspace @sorry-cypress/api build
-RUN yarn install --production --frozen-lockfile
-RUN apk --no-cache add curl && \
-    curl -sf https://gobinaries.com/tj/node-prune | sh && \
-    node-prune
+RUN yarn install --production --frozen-lockfile --network-timeout 300000
+
 
 FROM node:16-alpine
 ARG USER=node

--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -6,7 +6,7 @@ COPY packages/common/ ./packages/common
 COPY package.json ./
 COPY yarn.lock ./
 COPY tsconfig.json ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 300000
 RUN yarn workspace @sorry-cypress/common build
 RUN yarn workspace @sorry-cypress/dashboard build
 

--- a/packages/director/Dockerfile
+++ b/packages/director/Dockerfile
@@ -7,17 +7,14 @@ COPY packages/logger/ ./packages/logger
 COPY package.json ./
 COPY yarn.lock ./
 COPY tsconfig.json ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 300000
 
 RUN yarn workspace @sorry-cypress/common build
 RUN yarn workspace @sorry-cypress/mongo build
 RUN yarn workspace @sorry-cypress/logger build
 RUN yarn workspace @sorry-cypress/director build
 
-RUN yarn install --production --frozen-lockfile
-RUN apk --no-cache add curl && \
-    curl -sf https://gobinaries.com/tj/node-prune | sh && \
-    node-prune
+RUN yarn install --production --frozen-lockfile --network-timeout 300000
 
 FROM node:16-alpine
 ARG USER=node

--- a/scripts/release-dockerhub.sh
+++ b/scripts/release-dockerhub.sh
@@ -44,9 +44,9 @@ function getTagsArg() {
 }
 
 function dockerBuild() {
-  echo 🔨 Building ${2} from ${1}: docker buildx build --file ${1}/Dockerfile --platforms=linux/arm/v7,linux/amd64 $(getTagsArg ${2})
+  echo 🔨 Building ${2} from ${1}: docker buildx build --file ${1}/Dockerfile --platform=linux/arm/v7,linux/amd64 $(getTagsArg ${2})
   echo ========================
-  docker buildx build --file ${1}/Dockerfile --platforms=linux/arm/v7,linux/amd64 $(getTagsArg ${2}) .
+  docker buildx build --file ${1}/Dockerfile --platform=linux/arm/v7,linux/amd64 $(getTagsArg ${2}) .
   echo ========================
   echo ✅ Build completed ${2} from ${1} 
 }

--- a/scripts/release-dockerhub.sh
+++ b/scripts/release-dockerhub.sh
@@ -44,9 +44,9 @@ function getTagsArg() {
 }
 
 function dockerBuild() {
-  echo 🔨 Building ${2} from ${1}: docker build --file ${1}/Dockerfile $(getTagsArg ${2})
+  echo 🔨 Building ${2} from ${1}: docker buildx build --file ${1}/Dockerfile --platforms=linux/arm/v7,linux/amd64 $(getTagsArg ${2})
   echo ========================
-  docker build --file ${1}/Dockerfile $(getTagsArg ${2}) .
+  docker buildx build --file ${1}/Dockerfile --platforms=linux/arm/v7,linux/amd64 $(getTagsArg ${2}) .
   echo ========================
   echo ✅ Build completed ${2} from ${1} 
 }


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link [here](https://github.com/sorry-cypress/gitbook/pull/24)
- [x] I have added inclued automated tests
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: [here](https://github.com/sorry-cypress/sorry-cypress/issues/734)

## Use case

Running ARM instances especially in AWS is cheaper and more performant. This will allow users to deploy it on AMD or ARM instances

## Example

Running locally you can see how this works
```
docker buildx build --file ./packages/api/Dockerfile --platform=linux/arm/v7,linux/amd64 .
[+] Building 1089.0s (41/41) FINISHED                                                                                     
 => [internal] load build definition from Dockerfile                                                                 0.0s
 => => transferring dockerfile: 935B                                                                                 0.0s
 => [internal] load .dockerignore                                                                                    0.0s
 => => transferring context: 66B                                                                                     0.0s
 => [linux/arm/v7 internal] load metadata for docker.io/library/node:16-alpine                                       0.3s
 => [linux/amd64 internal] load metadata for docker.io/library/node:16-alpine                                        0.3s
 => [internal] load build context                                                                                    0.0s
 => => transferring context: 5.47kB                                                                                  0.0s
 => [linux/arm/v7 build  1/15] FROM docker.io/library/node:16-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d7  0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d72743816663664cfe9aa15  0.0s
 => [linux/amd64 build  1/15] FROM docker.io/library/node:16-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d72  0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1298fd170c45954fec3d4d063437750f89802d72743816663664cfe9aa15  0.0s
 => CACHED [linux/arm/v7 build  2/15] WORKDIR /app                                                                   0.0s
 => CACHED [linux/amd64 build  2/15] WORKDIR /app                                                                    0.0s
 => [linux/arm/v7 build  3/15] COPY packages/api/ ./packages/api                                                     0.0s
 => [linux/amd64 build  3/15] COPY packages/api/ ./packages/api                                                      0.0s
 => [linux/amd64 build  4/15] COPY packages/common/ ./packages/common                                                0.1s
 => [linux/arm/v7 build  4/15] COPY packages/common/ ./packages/common                                               0.1s
 => [linux/amd64 build  5/15] COPY packages/mongo/ ./packages/mongo                                                  0.0s
 => [linux/arm/v7 build  5/15] COPY packages/mongo/ ./packages/mongo                                                 0.0s
 => [linux/amd64 build  6/15] COPY packages/logger/ ./packages/logger                                                0.0s
 => [linux/arm/v7 build  6/15] COPY packages/logger/ ./packages/logger                                               0.0s
 => [linux/amd64 build  7/15] COPY package.json ./                                                                   0.0s
 => [linux/arm/v7 build  7/15] COPY package.json ./                                                                  0.0s
 => [linux/amd64 build  8/15] COPY yarn.lock ./                                                                      0.1s
 => [linux/arm/v7 build  8/15] COPY yarn.lock ./                                                                     0.0s
 => [linux/amd64 build  9/15] COPY tsconfig.json ./                                                                  0.0s
 => [linux/arm/v7 build  9/15] COPY tsconfig.json ./                                                                 0.0s
 => [linux/amd64 build 10/15] RUN yarn install --frozen-lockfile --network-timeout 300000                          119.7s
 => [linux/arm/v7 build 10/15] RUN yarn install --frozen-lockfile --network-timeout 300000                         395.7s
 => [linux/amd64 build 11/15] RUN yarn workspace @sorry-cypress/common build                                        25.8s
 => [linux/amd64 build 12/15] RUN yarn workspace @sorry-cypress/mongo build                                         22.8s
 => [linux/amd64 build 13/15] RUN yarn workspace @sorry-cypress/logger build                                        17.0s
 => [linux/amd64 build 14/15] RUN yarn workspace @sorry-cypress/api build                                           36.5s
 => [linux/amd64 build 15/15] RUN yarn install --production --frozen-lockfile --network-timeout 300000              15.9s
 => [linux/amd64 stage-1 3/5] COPY  --chown=node:node --from=build /app/packages/ packages/                          0.1s
 => [linux/amd64 stage-1 4/5] COPY  --chown=node:node --from=build /app/node_modules/ node_modules/                  2.0s
 => [linux/amd64 stage-1 5/5] RUN apk add --no-cache tini                                                            1.6s
 => [linux/arm/v7 build 11/15] RUN yarn workspace @sorry-cypress/common build                                      151.7s
 => [linux/arm/v7 build 12/15] RUN yarn workspace @sorry-cypress/mongo build                                       147.3s
 => [linux/arm/v7 build 13/15] RUN yarn workspace @sorry-cypress/logger build                                      105.8s
 => [linux/arm/v7 build 14/15] RUN yarn workspace @sorry-cypress/api build                                         211.3s
 => [linux/arm/v7 build 15/15] RUN yarn install --production --frozen-lockfile --network-timeout 300000             66.9s
 => [linux/arm/v7 stage-1 3/5] COPY  --chown=node:node --from=build /app/packages/ packages/                         0.1s
 => [linux/arm/v7 stage-1 4/5] COPY  --chown=node:node --from=build /app/node_modules/ node_modules/                 2.2s
 => [linux/arm/v7 stage-1 5/5] RUN apk add --no-cache tini                                                           5.6s
 ```