### PR TITLE
Fix Multi Arch Build

### DIFF
--- a/scripts/release-dockerhub.sh
+++ b/scripts/release-dockerhub.sh
@@ -43,10 +43,18 @@ function getTagsArg() {
   done
 }
 
-function dockerBuild() {
-  echo 🔨 Building ${2} from ${1}: docker build --file ${1}/Dockerfile $(getTagsArg ${2})
+function dockerBuildxSetup() {
+  echo Setting Up Docker Buildx
   echo ========================
-  docker build --file ${1}/Dockerfile $(getTagsArg ${2}) .
+  docker buildx create --platform=linux/arm/v7,linux/amd64 --use
+  echo ========================
+  echo ✅ Build completed ${2} from ${1} 
+}
+
+function dockerBuild() {
+  echo 🔨 Building ${2} from ${1}: docker buildx build --file ${1}/Dockerfile --platform=linux/arm/v7,linux/amd64 $(getTagsArg ${2})
+  echo ========================
+  docker buildx build --file ${1}/Dockerfile --platform=linux/arm/v7,linux/amd64 $(getTagsArg ${2}) .
   echo ========================
   echo ✅ Build completed ${2} from ${1} 
 }
@@ -87,6 +95,8 @@ fi
 
 echo 🚀 Releasing tags: $TAGS
 echo ========================
+
+dockerBuildxSetup
 
 dockerBuild "packages/${service}" "agoldis/sorry-cypress-${service}"
 # dockerBuild "packages/api" "agoldis/sorry-cypress-api"


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [x] I have added inclued automated tests
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: `<here>`

## Use case

ARM and AMD builds

## Example

Fixes last attempt by fixing typo on `docker buildx create`
```
-> docker buildx create --platform=linux/arm/v7,linux/amd64 --use 
pedantic_jennings
```