### PR TITLE
chore: bitbucket cloud url processing for commit and PR links

### DIFF
--- a/packages/dashboard/src/lib/bitbucketCloud.ts
+++ b/packages/dashboard/src/lib/bitbucketCloud.ts
@@ -1,0 +1,10 @@
+export const getBitbucketCloudCommitURL = (repo: string, sha: string) =>
+  handleBitbucketCloudSshURL(repo + `/commits/${sha}`);
+
+export const getBitbucketCloudBranchURL = (repo: string, branch: string) =>
+  handleBitbucketCloudSshURL(
+    repo + `/pull-requests/${branch.replace(/PR-/, '')}`
+  );
+
+export const handleBitbucketCloudSshURL = (sshUrl: string) =>
+  sshUrl.replace(/git@([\w.]+):(.+).git/, 'https://$1/$2');

--- a/packages/dashboard/src/lib/github.ts
+++ b/packages/dashboard/src/lib/github.ts
@@ -1,8 +1,8 @@
 export const getGithubCommitURL = (repo: string, sha: string) =>
-  handleSshURL(repo.replace(/.git$/, '') + `/commit/${sha}`);
+  handleGithubSshURL(repo.replace(/.git$/, '') + `/commit/${sha}`);
 
 export const getGithubBranchURL = (repo: string, branch: string) =>
-  handleSshURL(repo.replace(/.git$/, '') + `/tree/${branch}`);
+  handleGithubSshURL(repo.replace(/.git$/, '') + `/tree/${branch}`);
 
-export const handleSshURL = (sshUrl: string) =>
+export const handleGithubSshURL = (sshUrl: string) =>
   sshUrl.replace(/git@([\w.]+):(.+)/, 'https://$1/$2');

--- a/packages/dashboard/src/lib/repository.ts
+++ b/packages/dashboard/src/lib/repository.ts
@@ -1,0 +1,25 @@
+import {
+  getBitbucketCloudBranchURL,
+  getBitbucketCloudCommitURL,
+  handleBitbucketCloudSshURL,
+} from '@sorry-cypress/dashboard/lib/bitbucketCloud';
+import {
+  getGithubBranchURL,
+  getGithubCommitURL,
+  handleGithubSshURL,
+} from '@sorry-cypress/dashboard/lib/github';
+
+export const getCommitURL = (repo: string, sha: string) =>
+  repo.includes('bitbucket.org')
+    ? getBitbucketCloudCommitURL(repo, sha)
+    : getGithubCommitURL(repo, sha); // github is default
+
+export const getBranchURL = (repo: string, branch: string) =>
+  repo.includes('bitbucket.org')
+    ? getBitbucketCloudBranchURL(repo, branch)
+    : getGithubBranchURL(repo, branch); // github is default
+
+export const handleSshURL = (sshUrl: string) =>
+  sshUrl.includes('bitbucket.org')
+    ? handleBitbucketCloudSshURL(sshUrl)
+    : handleGithubSshURL(sshUrl); // github is default

--- a/packages/dashboard/src/run/commit/commit.tsx
+++ b/packages/dashboard/src/run/commit/commit.tsx
@@ -7,10 +7,10 @@ import {
 import { Grid, Link, Tooltip, Typography } from '@mui/material';
 import { Commit as CommitDef } from '@sorry-cypress/dashboard/generated/graphql';
 import {
-  getGithubBranchURL,
-  getGithubCommitURL,
+  getBranchURL,
+  getCommitURL,
   handleSshURL,
-} from '@sorry-cypress/dashboard/lib/github';
+} from '@sorry-cypress/dashboard/lib/repository';
 import React, { FunctionComponent } from 'react';
 import { CommitMessage } from '../commitMessage';
 
@@ -79,10 +79,7 @@ export const Commit: CommitComponent = (props) => {
                   <Link
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={getGithubBranchURL(
-                      commit.remoteOrigin,
-                      commit.branch
-                    )}
+                    href={getBranchURL(commit.remoteOrigin, commit.branch)}
                     underline="hover"
                   >
                     {commit.branch}
@@ -139,7 +136,7 @@ export const Commit: CommitComponent = (props) => {
                 <Link
                   target="_blank"
                   rel="noopener noreferrer"
-                  href={getGithubCommitURL(commit.remoteOrigin, commit.sha)}
+                  href={getCommitURL(commit.remoteOrigin, commit.sha)}
                   underline="hover"
                 >
                   <CommitMessage brief={brief} message={commit.message} />


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [ X] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [ X] I have added included automated tests
- [ X] I acknowledge that I have tested that the change is backwards-compatible
- [ X] Original issue / feature request / discussion: `<here>`

## Use case

Dashboard would use a separate function to treat Bitbucket Cloud links to Commits and PRs. 
`https://bitbucket.org/<org>/<repo>/commits/<hash>` <-- commit**S**
`https://bitbucket.org/<org>/<repo>/pull-requests/76` <-- pull-requests instead of tree, and PR- removed

I'm including the Bitbucket update in this PR. There is also new lib/repository.ts that detects if github/bitbucket is being used and returns correct implementation to the commit.tsx
This is basic but easy to read and understand and hopefully easy to extend for others like GitLabs or Bitbucket server. 

## Example
> Submit screenshots / outputs / tests together with the PR.

Documentation: this is an invisible improvement and I didn't see any section on gitbook that would warrant an addition, please correct if I'm wrong.
Tests: I would have written unit tests but the Dashboard does not look to have any test framework added (like jest) and preferred not to introduce too much change.

Bitbucket url to ssh regex should be working:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30108240/233309095-8bc094c0-2010-4f42-8808-8202f04ea9a9.png">


We are looking forward to using Sorry Cypress with Bitbucket cloud. Thanks!
