### PR TITLE
Setup docker multiarch build for amd64 and arm64 architectures

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-alpine AS build
+ARG BUILD_PLATFORM=linux/amd64
+FROM --platform="${BUILD_PLATFORM}" node:16-alpine AS build
 WORKDIR /app
 COPY packages/api/ ./packages/api
 COPY packages/common/ ./packages/common

--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-alpine AS build
+ARG BUILD_PLATFORM=linux/amd64
+FROM --platform="${BUILD_PLATFORM}" node:16-alpine AS build
 WORKDIR /app
 COPY packages/api/src/schema ./packages/api/src/schema
 COPY packages/dashboard/ ./packages/dashboard

--- a/packages/director/Dockerfile
+++ b/packages/director/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-alpine AS build
+ARG BUILD_PLATFORM=linux/amd64
+FROM --platform="${BUILD_PLATFORM}" node:16-alpine AS build
 WORKDIR /app
 COPY packages/director/ ./packages/director/
 COPY packages/common/ ./packages/common

--- a/scripts/release-dockerhub.sh
+++ b/scripts/release-dockerhub.sh
@@ -43,23 +43,12 @@ function getTagsArg() {
   done
 }
 
-function dockerBuild() {
-  echo 🔨 Building ${2} from ${1}: docker build --file ${1}/Dockerfile $(getTagsArg ${2})
+function dockerBuildAndPush() {
+  echo 🔨 Building and 💾 pushing ${2} from ${1} to remote: docker buildx build --push --platform linux/arm64/v8,linux/amd64 --file ${1}/Dockerfile $(getTagsArg ${2})
   echo ========================
-  docker build --file ${1}/Dockerfile $(getTagsArg ${2}) .
+  docker buildx build --push --platform linux/arm64/v8,linux/amd64 --file ${1}/Dockerfile $(getTagsArg ${2}) .
   echo ========================
   echo ✅ Build completed ${2} from ${1} 
-}
-
-function dockerPush() {
-  for TAG in ${TAGS}
-  do
-    echo 💾 Pushing to remote: docker push ${1}:${TAG}
-    echo ========================
-    docker push "${1}:${TAG}"
-    echo ========================
-    echo ✅ Pushed "${1}:${TAG}"
-  done
 }
 
 # ./scripts/release-dockerhub.sh -t cypress-v5
@@ -88,13 +77,9 @@ fi
 echo 🚀 Releasing tags: $TAGS
 echo ========================
 
-dockerBuild "packages/${service}" "agoldis/sorry-cypress-${service}"
-# dockerBuild "packages/api" "agoldis/sorry-cypress-api"
-# dockerBuild "packages/dashboard" "agoldis/sorry-cypress-dashboard"
-
-dockerPush "agoldis/sorry-cypress-${service}"
-# dockerPush "agoldis/sorry-cypress-api"
-# dockerPush "agoldis/sorry-cypress-dashboard"
+dockerBuildAndPush "packages/${service}" "agoldis/sorry-cypress-${service}"
+# dockerBuildAndPush "packages/api" "agoldis/sorry-cypress-api"
+# dockerBuildAndPush "packages/dashboard" "agoldis/sorry-cypress-dashboard"
 
 echo ========================
 echo 🎉 Released to Dockerhub: $TAGS


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [X] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [X] I have added inclued automated tests
- [X] I acknowledge that I have tested that the change is backwards-compatible
- [X] Original issue / feature request / discussion: `<here>`

## Use case

ARM architectures become progressively more popular in cloud solutions, in particular with AWS investing a lot with their Graviton solution. As a result, most of official Docker in DockerHub now support multiple CPU architectures including `arm64`.

I am using AWS in several Kubernetes clusters and I am willing to switch to ARM to benefit from their impressive performance/cost ratio, and I would like to deploy sorry-cypress on them.

So I propose in this PR a modification to the release process to build multi-architecture Docker images for the API, director and dashboard. This is greatly simplified thanks to the Node runtime that avoid the need of platform-specific binaries, and the `buildx` extension available along with Docker to build multi-architecture Docker images in a single command.

You will note that the `builder` stage of the Dockerfiles is pinned to the `amd64` platform by default (configurable with a build arg named `BUILD_PLATFORM`). Github Action workers indeed use the `amd64` platform. This is done to limit at maximum the impact on build time because building `arm64` images on `amd64` architecture requires the very slow QEMU emulation. On top of that, `buildx` extension is sufficiently smart to build only once the `build` stage, and then use it to build both final Docker images.

## Example

No specific example, once merged and a new version of sorry-cypress is released, the end user will be able to run locally or on Kubernetes for both `amd64` and `arm64` architecture with no change in commands or configuration (OCI runtimes takes care of pulling the appropriate image for the target architecture).
