### PR TITLE
feat: add UPLOAD_EXPIRY_SECONDS for signed URL

### DIFF
--- a/packages/director/src/screenshots/minio/config.ts
+++ b/packages/director/src/screenshots/minio/config.ts
@@ -1,9 +1,17 @@
 export const MINIO_BUCKET = process.env.MINIO_BUCKET || 'sorry-cypress';
-export const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'defaultAccessKey';
+export const MINIO_ACCESS_KEY =
+  process.env.MINIO_ACCESS_KEY || 'defaultAccessKey';
 export const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'defaultSecret';
 export const MINIO_ACL = process.env.MINIO_ACL || 'public-read';
 export const MINIO_READ_URL_PREFIX = process.env.MINIO_READ_URL_PREFIX || null;
-export const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT || 'storage.yourdomain.com';
+export const MINIO_ENDPOINT =
+  process.env.MINIO_ENDPOINT || 'storage.yourdomain.com';
 export const MINIO_PORT = process.env.MINIO_PORT || '9000';
 export const MINIO_USESSL = process.env.MINIO_USESSL || 'false';
-export const MINIO_URL = process.env.MINIO_URL || 'https://storage.yourdomain.com';
+export const MINIO_URL =
+  process.env.MINIO_URL || 'https://storage.yourdomain.com';
+
+export const UPLOAD_EXPIRY_SECONDS = parseInt(
+  process.env.UPLOAD_EXPIRY_SECONDS || '90',
+  90
+);

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -9,6 +9,7 @@ import {
   MINIO_SECRET_KEY,
   MINIO_URL,
   MINIO_USESSL,
+  UPLOAD_EXPIRY_SECONDS,
 } from './config';
 import { S3SignedUploadResult } from './types';
 
@@ -26,14 +27,17 @@ const minioClient = new Minio.Client({
 interface GetUploadURLParams {
   key: string;
   ContentType?: string;
+  expiry?: number;
 }
 export const getUploadUrl = async ({
   key,
+  expiry = UPLOAD_EXPIRY_SECONDS,
 }: GetUploadURLParams): Promise<S3SignedUploadResult> => {
   return new Promise((resolve, reject) => {
     minioClient.presignedPutObject(
       MINIO_BUCKET,
       key,
+      expiry,
       (error: Error, uploadUrl: string) => {
         if (error) {
           return reject(error);

--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -5,3 +5,7 @@ export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE || false;
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || undefined;
 export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || undefined;
 export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || undefined;
+export const UPLOAD_EXPIRY_SECONDS = parseInt(
+  process.env.UPLOAD_EXPIRY_SECONDS || '90',
+  90
+);

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -9,6 +9,7 @@ import {
   S3_READ_URL_PREFIX,
   S3_REGION,
   S3_VIDEO_KEY_PREFIX,
+  UPLOAD_EXPIRY_SECONDS,
 } from './config';
 import { S3SignedUploadResult } from './types';
 
@@ -33,7 +34,7 @@ interface GetUploadURLParams {
 export const getUploadUrl = async ({
   key,
   ContentType = ImageContentType,
-  Expires = 60,
+  Expires = UPLOAD_EXPIRY_SECONDS,
 }: GetUploadURLParams): Promise<S3SignedUploadResult> => {
   const s3Params = {
     Bucket: S3_BUCKET,
@@ -73,5 +74,5 @@ export const getVideoUploadUrl = async (
   getUploadUrl({
     key: `${sanitizeS3KeyPrefix(S3_VIDEO_KEY_PREFIX)}${key}.mp4`,
     ContentType: VideoContentType,
-    Expires: 90,
+    Expires: UPLOAD_EXPIRY_SECONDS,
   });


### PR DESCRIPTION
Add `UPLOAD_EXPIRY_SECONDS` to control the expiration time for signed URLs