### PR TITLE
Support signed S3 download URLs

### DIFF
--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -313,6 +313,7 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Join ['-', [!Ref 'AWS::StackName', 'test-results']]
+      AccessControl: PublicRead
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:

--- a/cloudformation/sorry-cypress.yml
+++ b/cloudformation/sorry-cypress.yml
@@ -313,7 +313,6 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Join ['-', [!Ref 'AWS::StackName', 'test-results']]
-      AccessControl: PublicRead
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:

--- a/packages/common/src/instance/types.ts
+++ b/packages/common/src/instance/types.ts
@@ -76,7 +76,7 @@ export interface ScreenshotUploadInstruction extends AssetUploadInstruction {
   screenshotId: string;
 }
 
-export interface ScreenshotDownloadInstruction extends AssetUDownloadInstruction {
+export interface ScreenshotDownloadInstruction extends AssetDownloadInstruction {
   screenshotId: string;
 }
 

--- a/packages/common/src/instance/types.ts
+++ b/packages/common/src/instance/types.ts
@@ -68,7 +68,15 @@ export interface AssetUploadInstruction {
   readUrl: string;
 }
 
+export interface AssetDownloadInstruction {
+  downloadUrl: string;
+}
+
 export interface ScreenshotUploadInstruction extends AssetUploadInstruction {
+  screenshotId: string;
+}
+
+export interface ScreenshotDownloadInstruction extends AssetUDownloadInstruction {
   screenshotId: string;
 }
 

--- a/packages/dashboard/src/instance/instanceDetails.tsx
+++ b/packages/dashboard/src/instance/instanceDetails.tsx
@@ -3,6 +3,21 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import TreeItem from '@mui/lab/TreeItem';
 import TreeView from '@mui/lab/TreeView';
+import aws from 'aws-sdk';
+import { AssetDownloadInstruction } from '@sorry-cypress/common';
+import {
+  S3_ACL,
+  S3_BUCKET,
+  S3_REGION,
+  S3_PRESIGN_DOWNLOAD_URLS,
+  S3_FORCE_PATH_STYLE,
+  S3_READ_URL_PREFIX,
+  S3_IMAGE_KEY_PREFIX,
+  S3_VIDEO_KEY_PREFIX,
+  S3_DOWNLOAD_EXPIRY_SECONDS,
+} from '../../../director/src/screenshots/s3/config';
+import * as s3 from '../../../director/src/screenshots/s3/s3';
+import { S3SignedDownloadResult } from '../../../director/src/screenshots/s3/types';
 import {
   Alert,
   AlertTitle,
@@ -359,6 +374,13 @@ function getTreeOfNavigationItems(instance: GetInstanceQuery['instance']) {
 
   // if instance has video add it as the first item of the navigation tree
   if (instance?.results?.videoUrl) {
+
+    if (S3_PRESIGN_DOWNLOAD_URLS === true) {
+      const key = instance.results.videoUrl.split('/').pop()  // split url and get last item to get object key
+      const signedDownloadUrl = s3.getDownloadUrl(key)
+      instance.results.videoUrl = signedDownloadUrl
+    }
+
     navigationTree.set('RECORDED_VIDEO', {
       id: 'RECORDED_VIDEO',
       isVideo: true,

--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -6,8 +6,8 @@ export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || undefined;
 export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || undefined;
 export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || undefined;
 export const S3_PRESIGN_DOWNLOAD_URLS = process.env.S3_PRESIGN_DOWNLOAD_URLS || false;
-export const S3_UPLOAD_EXPIRY_SECONDS = parseInt(
-  process.env.S3_UPLOAD_EXPIRY_SECONDS || '90',
+export const UPLOAD_EXPIRY_SECONDS = parseInt(
+  process.env.UPLOAD_EXPIRY_SECONDS || '90',
   90
 );
 export const S3_DOWNLOAD_EXPIRY_SECONDS = parseInt(

--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -5,7 +5,12 @@ export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE || false;
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || undefined;
 export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || undefined;
 export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || undefined;
-export const UPLOAD_EXPIRY_SECONDS = parseInt(
-  process.env.UPLOAD_EXPIRY_SECONDS || '90',
+export const S3_PRESIGN_DOWNLOAD_URLS = process.env.S3_PRESIGN_DOWNLOAD_URLS || false;
+export const S3_UPLOAD_EXPIRY_SECONDS = parseInt(
+  process.env.S3_UPLOAD_EXPIRY_SECONDS || '90',
+  90
+);
+export const S3_DOWNLOAD_EXPIRY_SECONDS = parseInt(
+  process.env.S3_DOWNLOAD_EXPIRY_SECONDS || '90',
   90
 );

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -1,4 +1,4 @@
-import { AssetUploadInstruction,AssetDownloadInstruction } from '@sorry-cypress/common';
+import { AssetUploadInstruction, AssetDownloadInstruction } from '@sorry-cypress/common';
 import aws from 'aws-sdk';
 import { sanitizeS3KeyPrefix } from '../utils/';
 import {

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -9,7 +9,7 @@ import {
   S3_READ_URL_PREFIX,
   S3_REGION,
   S3_VIDEO_KEY_PREFIX,
-  S3_UPLOAD_EXPIRY_SECONDS,
+  UPLOAD_EXPIRY_SECONDS,
   S3_DOWNLOAD_EXPIRY_SECONDS,
   S3_PRESIGN_DOWNLOAD_URLS
 } from './config';
@@ -42,7 +42,7 @@ interface GetDownloadURLParams {
 export const getUploadUrl = async ({
   key,
   ContentType = ImageContentType,
-  Expires = S3_UPLOAD_EXPIRY_SECONDS,
+  Expires = UPLOAD_EXPIRY_SECONDS,
 }: GetUploadURLParams): Promise<S3SignedUploadResult> => {
   const s3Params = {
     Bucket: S3_BUCKET,
@@ -82,7 +82,7 @@ export const getVideoUploadUrl = async (
   getUploadUrl({
     key: `${sanitizeS3KeyPrefix(S3_VIDEO_KEY_PREFIX)}${key}.mp4`,
     ContentType: VideoContentType,
-    Expires: S3_UPLOAD_EXPIRY_SECONDS,
+    Expires: UPLOAD_EXPIRY_SECONDS,
   });
 
 // Signed downloads

--- a/packages/director/src/screenshots/s3/s3.ts
+++ b/packages/director/src/screenshots/s3/s3.ts
@@ -1,4 +1,4 @@
-import { AssetUploadInstruction } from '@sorry-cypress/common';
+import { AssetUploadInstruction,AssetDownloadInstruction } from '@sorry-cypress/common';
 import aws from 'aws-sdk';
 import { sanitizeS3KeyPrefix } from '../utils/';
 import {
@@ -9,9 +9,11 @@ import {
   S3_READ_URL_PREFIX,
   S3_REGION,
   S3_VIDEO_KEY_PREFIX,
-  UPLOAD_EXPIRY_SECONDS,
+  S3_UPLOAD_EXPIRY_SECONDS,
+  S3_DOWNLOAD_EXPIRY_SECONDS,
+  S3_PRESIGN_DOWNLOAD_URLS
 } from './config';
-import { S3SignedUploadResult } from './types';
+import { S3SignedUploadResult, S3SignedDownloadResult } from './types';
 
 const BUCKET_URL = S3_FORCE_PATH_STYLE
   ? `https://s3.amazonaws.com/${S3_BUCKET}`
@@ -31,10 +33,16 @@ interface GetUploadURLParams {
   Expires?: number;
 }
 
+interface GetDownloadURLParams {
+  key: string;
+  Expires?: number;
+}
+
+// Signed uploads
 export const getUploadUrl = async ({
   key,
   ContentType = ImageContentType,
-  Expires = UPLOAD_EXPIRY_SECONDS,
+  Expires = S3_UPLOAD_EXPIRY_SECONDS,
 }: GetUploadURLParams): Promise<S3SignedUploadResult> => {
   const s3Params = {
     Bucket: S3_BUCKET,
@@ -74,5 +82,47 @@ export const getVideoUploadUrl = async (
   getUploadUrl({
     key: `${sanitizeS3KeyPrefix(S3_VIDEO_KEY_PREFIX)}${key}.mp4`,
     ContentType: VideoContentType,
-    Expires: UPLOAD_EXPIRY_SECONDS,
+    Expires: S3_UPLOAD_EXPIRY_SECONDS,
+  });
+
+// Signed downloads
+export const getDownloadUrl = async ({
+  key,
+  Expires = S3_DOWNLOAD_EXPIRY_SECONDS,
+}: GetDownloadURLParams): Promise<S3SignedDownloadResult> => {
+  const s3Params = {
+    Bucket: S3_BUCKET,
+    Key: key,
+    Expires
+  };
+
+  return new Promise((resolve, reject) => {
+    s3.getSignedUrl(
+      'getObject',
+      s3Params,
+      (error: Error, downloadUrl: string) => {
+        if (error) {
+          return reject(error);
+        }
+        return resolve({
+          downloadUrl: `${S3_READ_URL_PREFIX || BUCKET_URL}/${key}`
+        });
+      }
+    );
+  });
+};
+
+export const getImageDownloadUrl = async (
+  key: string
+): Promise<AssetDownloadInstruction> =>
+  getDownloadUrl({
+    key: `${sanitizeS3KeyPrefix(S3_IMAGE_KEY_PREFIX)}${key}.png`,
+  });
+
+export const getVideoDownloadUrl = async (
+  key: string
+): Promise<AssetDownloadInstruction> =>
+  getDownloadUrl({
+    key: `${sanitizeS3KeyPrefix(S3_VIDEO_KEY_PREFIX)}${key}.mp4`,
+    Expires: S3_DOWNLOAD_EXPIRY_SECONDS,
   });

--- a/packages/director/src/screenshots/s3/types.d.ts
+++ b/packages/director/src/screenshots/s3/types.d.ts
@@ -2,3 +2,7 @@ export interface S3SignedUploadResult {
   uploadUrl: string;
   readUrl: string;
 }
+
+export interface S3SignedDownloadResult {
+  downloadUrl: string;
+}


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [ ] I have added inclued automated tests
- [ ] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case

> For security reasons, the S3 screenshots bucket in my deployment was required to be encrypted with a CMK. This started leading to 400 Bad Request responses from S3 when the browser would try to download the video file for a test.

To get around this, SC should return signed download URLs.

## Example

> Submit screenshots / outputs / tests together with the PR.
