### PR TITLE
fix: fix parsing UPLOAD_EXPIRY_SECONDS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ## References
 
 - [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
-- [ ] I have added inclued automated tests
+- [ ] I have added included automated tests or evidence that it's working
 - [ ] I acknowledge that I have tested that the change is backwards-compatible
 - [ ] Original issue / feature request / discussion: `<here>`
 

--- a/packages/director/src/config.ts
+++ b/packages/director/src/config.ts
@@ -27,7 +27,6 @@ export const INACTIVITY_TIMEOUT_SECONDS = Number(
   process.env.INACTIVITY_TIMEOUT_SECONDS ?? 180
 );
 
-export const REDIS_URI = process.env.REDIS_URI;
 export const GITLAB_JOB_RETRIES = process.env.GITLAB_JOB_RETRIES || 'false';
 export const PROBE_LOGGER = process.env.PROBE_LOGGER || 'false';
 export const BASE_PATH = process.env.BASE_PATH || '/';

--- a/packages/director/src/screenshots/azure-blob-storage/azure-blob-storage.ts
+++ b/packages/director/src/screenshots/azure-blob-storage/azure-blob-storage.ts
@@ -4,6 +4,7 @@ import {
   AZURE_CONNEXION_STRING,
   AZURE_CONTAINER_NAME,
   AZURE_UPLOAD_URL_EXPIRY_IN_HOURS,
+  UPLOAD_EXPIRY_SECONDS,
 } from '@sorry-cypress/director/screenshots/azure-blob-storage/config';
 
 const blobServiceClient = BlobServiceClient.fromConnectionString(
@@ -24,8 +25,7 @@ export const getUploadUrl = async ({
 }: GetUploadURLParams): Promise<AssetUploadInstruction> => {
   const signedUploadUrlStartsOn = new Date();
   const signedUploadUrlExpiresOn = new Date(
-    signedUploadUrlStartsOn.getTime() +
-      3600 * 1000 * AZURE_UPLOAD_URL_EXPIRY_IN_HOURS
+    signedUploadUrlStartsOn.getTime() + 1000 * getExpirationSeconds()
   );
   const signedReadUrlStartsOn = new Date();
   const signedReadUrlExpiresOn = new Date(
@@ -65,3 +65,10 @@ export const getVideoUploadUrl = async (
     key: `${key}.mp4`,
     ContentType: VideoContentType,
   });
+
+function getExpirationSeconds() {
+  if (AZURE_UPLOAD_URL_EXPIRY_IN_HOURS) {
+    return AZURE_UPLOAD_URL_EXPIRY_IN_HOURS * 60 * 60;
+  }
+  return UPLOAD_EXPIRY_SECONDS;
+}

--- a/packages/director/src/screenshots/azure-blob-storage/config.ts
+++ b/packages/director/src/screenshots/azure-blob-storage/config.ts
@@ -4,3 +4,7 @@ export const AZURE_CONTAINER_NAME =
 export const AZURE_UPLOAD_URL_EXPIRY_IN_HOURS = parseInt(
   process.env.AZURE_UPLOAD_URL_EXPIRY_IN_HOURS || '24'
 );
+
+export const UPLOAD_EXPIRY_SECONDS = Number(
+  process.env.UPLOAD_EXPIRY_SECONhDS || '90'
+);

--- a/packages/director/src/screenshots/minio/config.ts
+++ b/packages/director/src/screenshots/minio/config.ts
@@ -11,7 +11,6 @@ export const MINIO_USESSL = process.env.MINIO_USESSL || 'false';
 export const MINIO_URL =
   process.env.MINIO_URL || 'https://storage.yourdomain.com';
 
-export const UPLOAD_EXPIRY_SECONDS = parseInt(
-  process.env.UPLOAD_EXPIRY_SECONDS || '90',
-  90
+export const UPLOAD_EXPIRY_SECONDS = Number(
+  process.env.UPLOAD_EXPIRY_SECONDS || '90'
 );

--- a/packages/director/src/screenshots/s3/config.ts
+++ b/packages/director/src/screenshots/s3/config.ts
@@ -5,7 +5,6 @@ export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE || false;
 export const S3_READ_URL_PREFIX = process.env.S3_READ_URL_PREFIX || undefined;
 export const S3_IMAGE_KEY_PREFIX = process.env.S3_IMAGE_KEY_PREFIX || undefined;
 export const S3_VIDEO_KEY_PREFIX = process.env.S3_VIDEO_KEY_PREFIX || undefined;
-export const UPLOAD_EXPIRY_SECONDS = parseInt(
-  process.env.UPLOAD_EXPIRY_SECONDS || '90',
-  10
+export const UPLOAD_EXPIRY_SECONDS = Number(
+  process.env.UPLOAD_EXPIRY_SECONDS || '90'
 );


### PR DESCRIPTION
closes #808

> PRs that do not follow the template will be automatically closed

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [ ] I have added inclued automated tests
- [ ] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case

> Describe the use-case in details

## Example

> Submit screenshots / outputs / tests together with the PR.
