### PR TITLE
Issues 804 : Add test chips status to projectList view

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - run cypress tests in parallel with no limitations
 - upload screenshots and videos to your own storage
 - browse test results, screenshots and video recordings
+- see all your projects test results in one page
 - self-hosted - use your own infrastructure, own your data
 - integrate with GitHub, Slack or anything else via webhooks
 - works on popular cloud platforms and your data center:

--- a/packages/dashboard/src/project/projectList.tsx
+++ b/packages/dashboard/src/project/projectList.tsx
@@ -1,17 +1,7 @@
 import { Fade, Grid, Skeleton } from '@mui/material';
-import { isTestFlaky } from '@sorry-cypress/common';
-import {
-  Paper,
-  TestFailureChip,
-  TestFlakyChip,
-  TestOverallChip,
-  TestPendingChip,
-  TestSkippedChip,
-  TestSuccessChip,
-} from '@sorry-cypress/dashboard/components';
+import { Paper } from '@sorry-cypress/dashboard/components';
 import {
   Filters,
-  useGetInstanceQuery,
   useGetProjectsQuery,
 } from '@sorry-cypress/dashboard/generated/graphql';
 import { ProjectListItem } from '@sorry-cypress/dashboard/project/projectListItem';
@@ -26,12 +16,12 @@ type ProjectsListProps = {
 const ProjectsList = ({ search }: ProjectsListProps) => {
   const filters: Filters[] = search
     ? [
-      {
-        value: (undefined as unknown) as null,
-        key: 'projectId',
-        like: search,
-      },
-    ]
+        {
+          value: (undefined as unknown) as null,
+          key: 'projectId',
+          like: search,
+        },
+      ]
     : [];
   const { loading, error, data, refetch } = useGetProjectsQuery({
     variables: {
@@ -98,8 +88,6 @@ const ProjectsList = ({ search }: ProjectsListProps) => {
         >
           <div>
             <ProjectListItem project={project} reloadProjects={refetch} />
-
-            <InstanceData projectId={project.projectId} />
           </div>
         </Grid>
       ))}
@@ -108,46 +96,3 @@ const ProjectsList = ({ search }: ProjectsListProps) => {
 };
 
 export default ProjectsList;
-
-// New component to fetch instance data for a project
-const InstanceData: React.FC<{ projectId: string }> = ({ projectId }) => {
-  const { loading, error, data } = useGetInstanceQuery({
-    variables: { instanceId: projectId },
-  });
-  if (loading) {
-    return <Skeleton variant="rectangular" height={88} />;
-  }
-  if (error || !data) {
-    return <p>Error fetching instance data</p>;
-  }
-  // Use the data to render the test chips
-  const instanceData = data.instance?.results?.stats;
-  if (!instanceData) {
-    return null;
-  }
-  const stats = data.instance?.results?.stats;
-  const flaky = data.instance?.results?.tests?.filter(isTestFlaky).length ?? 0;
-
-  return (
-    <Grid>
-      <Grid item>
-        <TestOverallChip value={stats?.tests ?? 0} />
-      </Grid>
-      <Grid item>
-        <TestSuccessChip value={stats?.passes ?? 0} />
-      </Grid>
-      <Grid item>
-        <TestFailureChip value={stats?.failures ?? 0} />
-      </Grid>
-      <Grid item>
-        <TestFlakyChip value={flaky} />
-      </Grid>
-      <Grid item>
-        <TestSkippedChip value={stats?.skipped ?? 0} />
-      </Grid>
-      <Grid item>
-        <TestPendingChip value={stats?.pending ?? 0} />
-      </Grid>
-    </Grid>
-  );
-};

--- a/packages/dashboard/src/project/projectListItem.tsx
+++ b/packages/dashboard/src/project/projectListItem.tsx
@@ -5,13 +5,27 @@ import {
   Card,
   CardActionArea,
   CardContent,
+  Grid,
   Link,
   ListItem,
   ListItemAvatar,
   ListItemText,
+  Skeleton,
 } from '@mui/material';
+import { isTestFlaky } from '@sorry-cypress/common';
 import { ArrayItemType } from '@sorry-cypress/common/ts';
-import { GetProjectsQuery } from '@sorry-cypress/dashboard/generated/graphql';
+import {
+  TestFailureChip,
+  TestFlakyChip,
+  TestOverallChip,
+  TestPendingChip,
+  TestSkippedChip,
+  TestSuccessChip,
+} from '@sorry-cypress/dashboard/components';
+import {
+  GetProjectsQuery,
+  useGetInstanceQuery,
+} from '@sorry-cypress/dashboard/generated/graphql';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
@@ -40,12 +54,12 @@ export function ProjectListItem({ project }: ProjectListItemProps) {
                 <Avatar
                   sx={{
                     backgroundColor: alpha(
-                      project.projectColor || '#3486E3',
+                      project.projectColor ?? '#3486E3',
                       0.1
                     ),
                   }}
                 >
-                  <Book sx={{ color: project.projectColor || '#3486E3' }} />
+                  <Book sx={{ color: project.projectColor ?? '#3486E3' }} />
                 </Avatar>
               </ListItemAvatar>
               <ListItemText
@@ -56,9 +70,49 @@ export function ProjectListItem({ project }: ProjectListItemProps) {
                 }}
               />
             </ListItem>
+            <InstanceData projectId={project.projectId} />
           </CardContent>
         </CardActionArea>
       </Card>
     </Link>
   );
 }
+
+// New component to fetch instance data for a project
+const InstanceData: React.FC<{ projectId: string }> = ({ projectId }) => {
+  const { loading, error, data } = useGetInstanceQuery({
+    variables: { instanceId: projectId },
+  });
+  if (loading) {
+    return <Skeleton variant="rectangular" height={88} />;
+  }
+  if (error || !data) {
+    return <p>Error fetching instance data</p>;
+  }
+
+  const stats = data.instance?.results?.stats;
+  const flaky = data.instance?.results?.tests?.filter(isTestFlaky).length ?? 0;
+
+  return (
+    <Grid container>
+      <Grid item>
+        <TestOverallChip value={stats?.tests ?? 0} />
+      </Grid>
+      <Grid item>
+        <TestSuccessChip value={stats?.passes ?? 0} />
+      </Grid>
+      <Grid item>
+        <TestFailureChip value={stats?.failures ?? 0} />
+      </Grid>
+      <Grid item>
+        <TestFlakyChip value={flaky} />
+      </Grid>
+      <Grid item>
+        <TestSkippedChip value={stats?.skipped ?? 0} />
+      </Grid>
+      <Grid item>
+        <TestPendingChip value={stats?.pending ?? 0} />
+      </Grid>
+    </Grid>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,9 +5897,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001280:
-  version "1.0.30001447"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz"
-  integrity sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==
+  version "1.0.30001519"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz"
+  integrity sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #804 
> PRs that do not follow the template will be automatically closed

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link [Updated doc](https://github.com/sorry-cypress/sorry-cypress/pull/833/commits/5326c75de103473abb057d14da4450b9fc9d5486)
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: [Issue 804](https://github.com/sorry-cypress/sorry-cypress/issues/804)

## Use case


> Describe the use-case in details
See below issue : [Issue 804](https://github.com/sorry-cypress/sorry-cypress/issues/804)

## Example

> Submit screenshots / outputs / tests together with the PR.
2 projects with tests executions and 1 project without any execution
![image](https://github.com/sorry-cypress/sorry-cypress/assets/22171928/f649a3d7-7c3f-4ee1-959e-4592daaec3a1)
I made the choice that when there is no execution, it will show 0 for all tests chips, but if you prefer, we can change that to show no chips. (In term of UI, I prefer with 0) :
![image](https://github.com/sorry-cypress/sorry-cypress/assets/22171928/c169d866-8b07-4bbe-ba5c-9e6239d0e1fc)


