### PR TITLE
Update slack.ts for improved newline formatting 

### DIFF
--- a/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequest.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequest.json
@@ -32,7 +32,7 @@
             "fields": [
               {
                 "type": "mrkdwn",
-                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Failed*: 0:white_circle: *Skipped*: 0:white_circle: *Ignored:* 0\n\n\n"
+                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Failed*: 0\n\n\n:white_circle: *Skipped*: 0\n\n\n:white_circle: *Ignored:* 0\n\n\n"
               },
               {
                 "type": "mrkdwn",

--- a/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequestWithoutCommitData.json
+++ b/packages/director/src/lib/hooks/__tests__/fixtures/slackReportStatusRequestWithoutCommitData.json
@@ -32,7 +32,7 @@
             "fields": [
               {
                 "type": "mrkdwn",
-                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Failed*: 0:white_circle: *Skipped*: 0:white_circle: *Ignored:* 0\n\n\n"
+                "text": ":large_green_circle: *Passed:* 1\n\n\n:white_circle: *Failed*: 0\n\n\n:white_circle: *Skipped*: 0\n\n\n:white_circle: *Ignored:* 0\n\n\n"
               }
             ]
           }

--- a/packages/director/src/lib/hooks/reporters/slack.ts
+++ b/packages/director/src/lib/hooks/reporters/slack.ts
@@ -79,8 +79,8 @@ export async function reportToSlack(
     } *Passed:* ${passes}\n\n\n` +
     `${
       failures > 0 ? ':red_circle:' : ':white_circle:'
-    } *Failed*: ${failures}` +
-    `${skipped > 0 ? ':red_circle:' : ':white_circle:'} *Skipped*: ${skipped}` +
+    } *Failed*: ${failures}\n\n\n` +
+    `${skipped > 0 ? ':red_circle:' : ':white_circle:'} *Skipped*: ${skipped}\n\n\n` +
     `${
       pending > 0 ? ':large_yellow_circle:' : ':white_circle:'
     } *Ignored:* ${pending}\n\n\n` +


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

-[n/a] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link <here>
-[x] I have added included automated tests or evidence that it's working
-[n/a] I acknowledge that I have tested that the change is backwards-compatible
-[x] Original issue / feature request / discussion: <here>

## Use case

This is purely a cosmetic improvement for slack reporting to handle newlines better.

## Example

![image](https://github.com/sorry-cypress/sorry-cypress/assets/53919283/93c9169e-dd34-48af-8488-9e464630f08d)

