### PR TITLE
feat: update instance summary

### DIFF
--- a/packages/api/src/generated/graphql.ts
+++ b/packages/api/src/generated/graphql.ts
@@ -99,6 +99,12 @@ export type CypressConfig = {
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
+export type CypressPlatform = {
+  __typename?: 'CypressPlatform';
+  browserName?: Maybe<Scalars['String']>;
+  browserVersion?: Maybe<Scalars['String']>;
+};
+
 export type DeleteHookInput = {
   hookId: Scalars['ID'];
   projectId: Scalars['String'];
@@ -204,6 +210,7 @@ export type HookInput = {
 
 export type Instance = {
   __typename?: 'Instance';
+  ciRunURL?: Maybe<Scalars['String']>;
   groupId: Scalars['String'];
   instanceId: Scalars['ID'];
   projectId: Scalars['String'];
@@ -505,6 +512,7 @@ export type RunMeta = {
   __typename?: 'RunMeta';
   ciBuildId: Scalars['String'];
   commit?: Maybe<Commit>;
+  platform?: Maybe<CypressPlatform>;
   projectId: Scalars['String'];
 };
 
@@ -759,6 +767,7 @@ export type ResolversTypes = {
   CreateSlackHookInput: CreateSlackHookInput;
   CreateTeamsHookInput: CreateTeamsHookInput;
   CypressConfig: ResolverTypeWrapper<CypressConfig>;
+  CypressPlatform: ResolverTypeWrapper<CypressPlatform>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
   DeleteHookInput: DeleteHookInput;
   DeleteHookResponse: ResolverTypeWrapper<DeleteHookResponse>;
@@ -831,6 +840,7 @@ export type ResolversParentTypes = {
   CreateSlackHookInput: CreateSlackHookInput;
   CreateTeamsHookInput: CreateTeamsHookInput;
   CypressConfig: CypressConfig;
+  CypressPlatform: CypressPlatform;
   DateTime: Scalars['DateTime'];
   DeleteHookInput: DeleteHookInput;
   DeleteHookResponse: DeleteHookResponse;
@@ -968,6 +978,23 @@ export type CypressConfigResolvers<
   video?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   videoUploadOnPasses?: Resolver<
     ResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CypressPlatformResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['CypressPlatform'] = ResolversParentTypes['CypressPlatform']
+> = {
+  browserName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  browserVersion?: Resolver<
+    Maybe<ResolversTypes['String']>,
     ParentType,
     ContextType
   >;
@@ -1188,6 +1215,7 @@ export type InstanceResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Instance'] = ResolversParentTypes['Instance']
 > = {
+  ciRunURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   groupId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   instanceId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1613,6 +1641,11 @@ export type RunMetaResolvers<
 > = {
   ciBuildId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   commit?: Resolver<Maybe<ResolversTypes['Commit']>, ParentType, ContextType>;
+  platform?: Resolver<
+    Maybe<ResolversTypes['CypressPlatform']>,
+    ParentType,
+    ContextType
+  >;
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1780,6 +1813,7 @@ export type Resolvers<ContextType = any> = {
   CiBuild?: CiBuildResolvers<ContextType>;
   Commit?: CommitResolvers<ContextType>;
   CypressConfig?: CypressConfigResolvers<ContextType>;
+  CypressPlatform?: CypressPlatformResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
   DeleteHookResponse?: DeleteHookResponseResolvers<ContextType>;
   DeleteProjectResponse?: DeleteProjectResponseResolvers<ContextType>;

--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -39,3 +39,10 @@ export const getSortByAggregation = (direction: OrderDirection = 'DESC') => ({
     _id: direction === 'DESC' ? -1 : 1,
   },
 });
+
+export type CiProvider = string | null;
+export const getCiRunURL = (provider: CiProvider) => {
+  if (provider && provider === 'GithubActions')
+    return process.env.GITHUB_ACTIONS_RUN_URL || '';
+  return null;
+};

--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -40,9 +40,6 @@ export const getSortByAggregation = (direction: OrderDirection = 'DESC') => ({
   },
 });
 
-export type CiProvider = string | null;
-export const getCiRunURL = (provider: CiProvider) => {
-  if (provider && provider === 'GithubActions')
-    return process.env.GITHUB_ACTIONS_RUN_URL || '';
-  return null;
+export const getCiRunURL = () => {
+  return process.env.CI_RUN_URL || '';
 };

--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -39,7 +39,3 @@ export const getSortByAggregation = (direction: OrderDirection = 'DESC') => ({
     _id: direction === 'DESC' ? -1 : 1,
   },
 });
-
-export const getCiRunURL = () => {
-  return process.env.CI_RUN_URL || '';
-};

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -22,6 +22,7 @@ import {
   UpdateSlackHookInput,
   UpdateTeamsHookInput,
 } from '@sorry-cypress/api/generated/graphql';
+import { getCiRunURL } from '@sorry-cypress/api/lib/query';
 import { Project } from '@sorry-cypress/common';
 import { GraphQLScalarType } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
@@ -134,7 +135,15 @@ export const resolvers = {
       if (!run) {
         return null;
       }
-      return { ...instance, projectId: run.meta.projectId, run };
+      const ciProvider = process.env.CI_PROVIDER || '';
+      const ciRunURL = getCiRunURL(ciProvider);
+
+      return {
+        ...instance,
+        ciRunURL,
+        projectId: run.meta.projectId,
+        run,
+      };
     },
   },
   Mutation: {

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -22,7 +22,6 @@ import {
   UpdateSlackHookInput,
   UpdateTeamsHookInput,
 } from '@sorry-cypress/api/generated/graphql';
-import { getCiRunURL } from '@sorry-cypress/api/lib/query';
 import { Project } from '@sorry-cypress/common';
 import { GraphQLScalarType } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
@@ -135,12 +134,12 @@ export const resolvers = {
       if (!run) {
         return null;
       }
-      const ciProvider = process.env.CI_PROVIDER || '';
-      const ciRunURL = getCiRunURL(ciProvider);
+
+      const CI_RUN_URL = process.env.CI_RUN_URL || '';
 
       return {
         ...instance,
-        ciRunURL,
+        ciRunURL: CI_RUN_URL,
         projectId: run.meta.projectId,
         run,
       };

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -152,8 +152,14 @@ type Commit {
   remoteOrigin: String
 }
 
+type CypressPlatform {
+  browserName: String
+  browserVersion: String
+}
+
 type RunMeta {
   ciBuildId: String!
+  platform: CypressPlatform
   projectId: String!
   commit: Commit
 }
@@ -180,6 +186,7 @@ type Instance {
   projectId: String!
   instanceId: ID!
   results: InstanceResults
+  ciRunURL: String
 }
 
 # Execution results of a single instance

--- a/packages/common/src/instance/types.ts
+++ b/packages/common/src/instance/types.ts
@@ -5,6 +5,7 @@ export interface Instance {
   runId: string;
   spec: string;
   cypressVersion: string;
+  ciRunURL: string;
   projectId: string;
   groupId: string;
   _createTestsPayload?: SetInstanceTestsPayload;

--- a/packages/dashboard/src/generated/graphql.ts
+++ b/packages/dashboard/src/generated/graphql.ts
@@ -93,6 +93,12 @@ export type CypressConfig = {
   videoUploadOnPasses: Scalars['Boolean'];
 };
 
+export type CypressPlatform = {
+  __typename?: 'CypressPlatform';
+  browserName: Maybe<Scalars['String']>;
+  browserVersion: Maybe<Scalars['String']>;
+};
+
 export type DeleteHookInput = {
   hookId: Scalars['ID'];
   projectId: Scalars['String'];
@@ -198,6 +204,7 @@ export type HookInput = {
 
 export type Instance = {
   __typename?: 'Instance';
+  ciRunURL: Maybe<Scalars['String']>;
   groupId: Scalars['String'];
   instanceId: Scalars['ID'];
   projectId: Scalars['String'];
@@ -499,6 +506,7 @@ export type RunMeta = {
   __typename?: 'RunMeta';
   ciBuildId: Scalars['String'];
   commit: Maybe<Commit>;
+  platform: Maybe<CypressPlatform>;
   projectId: Scalars['String'];
 };
 
@@ -708,10 +716,19 @@ export type GetInstanceQuery = {
     runId: string;
     spec: string;
     projectId: string;
+    ciRunURL: string | null;
     run: {
       __typename?: 'Run';
       runId: string;
-      meta: { __typename?: 'RunMeta'; ciBuildId: string };
+      meta: {
+        __typename?: 'RunMeta';
+        ciBuildId: string;
+        platform: {
+          __typename?: 'CypressPlatform';
+          browserName: string | null;
+          browserVersion: string | null;
+        } | null;
+      };
     };
     results: {
       __typename?: 'InstanceResults';
@@ -1557,6 +1574,10 @@ export const GetInstanceDocument = gql`
         runId
         meta {
           ciBuildId
+          platform {
+            browserName
+            browserVersion
+          }
         }
       }
       results {
@@ -1580,6 +1601,7 @@ export const GetInstanceDocument = gql`
         }
         videoUrl
       }
+      ciRunURL
     }
   }
   ${AllInstanceStatsFragmentDoc}

--- a/packages/dashboard/src/instance/getInstance.graphql
+++ b/packages/dashboard/src/instance/getInstance.graphql
@@ -8,6 +8,10 @@ query getInstance($instanceId: ID!) {
       runId
       meta {
         ciBuildId
+        platform {
+          browserName
+          browserVersion
+        }
       }
     }
     results {
@@ -31,5 +35,6 @@ query getInstance($instanceId: ID!) {
       }
       videoUrl
     }
+    ciRunURL
   }
 }

--- a/packages/dashboard/src/instance/instanceSummary.tsx
+++ b/packages/dashboard/src/instance/instanceSummary.tsx
@@ -1,5 +1,10 @@
-import { GroupWorkOutlined } from '@mui/icons-material';
-import { Alert, Grid, Tooltip, Typography } from '@mui/material';
+import {
+  AccessTime as AccessTimeIcon,
+  Code as CodeIcon,
+  GroupWorkOutlined,
+  Language as LanguageIcon,
+} from '@mui/icons-material';
+import { Alert, Grid, Link, Stack, Tooltip, Typography } from '@mui/material';
 import { isTestFlaky } from '@sorry-cypress/common';
 import {
   Chip,
@@ -20,8 +25,8 @@ import {
   GetInstanceQuery,
   InstanceStats,
 } from '@sorry-cypress/dashboard/generated/graphql';
+import { getDurationMs } from '@sorry-cypress/dashboard/lib/time';
 import React, { FunctionComponent } from 'react';
-import { getBase } from '../lib/path';
 
 export const InstanceSummary: InstanceSummaryComponent = (props) => {
   const { instance } = props;
@@ -31,29 +36,70 @@ export const InstanceSummary: InstanceSummaryComponent = (props) => {
   }
   const stats: InstanceStats = instance.results.stats;
   const flaky = instance.results.tests?.filter(isTestFlaky).length ?? 0;
+  const platform = instance.run.meta.platform;
 
   return (
     <Paper>
-      <Grid container direction="column" spacing={2}>
-        <Grid item>
+      <Grid container spacing={1} alignItems="center">
+        <Grid item xs={12}>
           <Typography component="h1" variant="h6" color="text.secondary">
-            {getBase(instance.spec)}
+            Run Details
           </Typography>
         </Grid>
-        <Grid item>
-          <Typography component="h2" variant="subtitle1">
-            {instance.spec}
+        <Grid item xs={12}>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Grid item>
+              <SpecStateChip
+                state={getInstanceState({
+                  claimedAt: null,
+                  stats: instance.results.stats,
+                })}
+              />
+            </Grid>
+            <Grid item xs>
+              <Typography component="h2" variant="subtitle1">
+                {instance.spec}
+              </Typography>
+            </Grid>
+          </Stack>
+        </Grid>
+        <Grid item xs={3}>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <AccessTimeIcon fontSize="small" />
+            <Typography variant="overline">Duration</Typography>
+          </Stack>
+          <Typography variant="body2">
+            {getDurationMs(stats.wallClockDuration)}
+          </Typography>
+        </Grid>
+        {instance.ciRunURL && (
+          <Grid item xs={6}>
+            <Stack direction="row" alignItems="center" gap={1}>
+              <CodeIcon fontSize="small" />
+              <Typography variant="overline">CI Run URL</Typography>
+            </Stack>
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href={instance.ciRunURL}
+              underline="hover"
+            >
+              {instance.ciRunURL.length > 60
+                ? `${instance.ciRunURL.substring(0, 60)}...`
+                : instance.ciRunURL}
+            </Link>
+          </Grid>
+        )}
+        <Grid item xs={3}>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <LanguageIcon fontSize="small" />
+            <Typography variant="overline">Browser</Typography>
+          </Stack>
+          <Typography variant="body2">
+            {platform?.browserName} {platform?.browserVersion}
           </Typography>
         </Grid>
         <Grid item container spacing={1}>
-          <Grid item>
-            <SpecStateChip
-              state={getInstanceState({
-                claimedAt: null,
-                stats: instance.results.stats,
-              })}
-            />
-          </Grid>
           <Grid item>
             <Tooltip title="Suites" arrow>
               <Chip

--- a/packages/dashboard/src/instance/instanceSummary.tsx
+++ b/packages/dashboard/src/instance/instanceSummary.tsx
@@ -43,7 +43,7 @@ export const InstanceSummary: InstanceSummaryComponent = (props) => {
       <Grid container spacing={1} alignItems="center">
         <Grid item xs={12}>
           <Typography component="h1" variant="h6" color="text.secondary">
-            Run Details
+            Test Details
           </Typography>
         </Grid>
         <Grid item xs={12}>


### PR DESCRIPTION
## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). [PR link](https://github.com/sorry-cypress/gitbook/pull/30)
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case

Adding more information to the Test Details section of each test result

-  Moved `Test Status` to the top
- Added Duration, Browser Name & Browser Version and CI Run URL
- If no `CI_RUN_URL` is available in the environment variables, CI Run URL column will not be displayed

## Example

Before:
<img width="1092" alt="Screenshot 2023-08-17 at 4 07 53 PM" src="https://github.com/sam-carvalho/sorry-cypress/assets/80129360/97c1d35e-fbcd-44a0-a6e3-11f0c01b7d58">

After:
<img width="1105" alt="Screenshot 2023-08-17 at 3 47 10 PM" src="https://github.com/sam-carvalho/sorry-cypress/assets/80129360/5d70fb7f-7b63-4bea-886a-c7813070f7bd">
<img width="1097" alt="Screenshot 2023-08-17 at 3 48 49 PM" src="https://github.com/sam-carvalho/sorry-cypress/assets/80129360/adcb01e3-5a0b-435a-86c5-776fe3997794">
<img width="688" alt="Screenshot 2023-08-17 at 3 53 24 PM" src="https://github.com/sam-carvalho/sorry-cypress/assets/80129360/95625b81-e08c-4a59-9f07-3809cf6e49b5">

