### PR TITLE
Issues 841 : Add a background color for each project of /project page

### DIFF
--- a/packages/dashboard/src/project/projectList.tsx
+++ b/packages/dashboard/src/project/projectList.tsx
@@ -13,8 +13,8 @@ import {
   useGetProjectsQuery,
 } from '@sorry-cypress/dashboard/generated/graphql';
 import {
-  getTestsFromProject,
   ProjectListItem,
+  useGetTestsFromProject,
 } from '@sorry-cypress/dashboard/project/projectListItem';
 import React from 'react';
 import { TransitionGroup } from 'react-transition-group';
@@ -114,7 +114,7 @@ export default ProjectsList;
 const SummaryComponent: React.FC<{ projects: Array<any> }> = ({ projects }) => {
   const aggregatedStats = projects.reduce(
     (acc, project) => {
-      const tests = getTestsFromProject(project);
+      const tests = useGetTestsFromProject(project);
       acc.tests += tests?.overall ?? 0;
       acc.passes += tests?.passes ?? 0;
       acc.failures += tests?.failures ?? 0;

--- a/packages/dashboard/src/project/projectListItem.tsx
+++ b/packages/dashboard/src/project/projectListItem.tsx
@@ -11,7 +11,7 @@ import {
   ListItemAvatar,
   ListItemText,
 } from '@mui/material';
-import { ArrayItemType } from '@sorry-cypress/common/ts';
+import { ArrayItemType, getRunTestsProgress } from '@sorry-cypress/common';
 import {
   TestFailureChip,
   TestFlakyChip,
@@ -20,7 +20,10 @@ import {
   TestSkippedChip,
   TestSuccessChip,
 } from '@sorry-cypress/dashboard/components';
-import { GetProjectsQuery } from '@sorry-cypress/dashboard/generated/graphql';
+import {
+  GetProjectsQuery,
+  RunProgress,
+} from '@sorry-cypress/dashboard/generated/graphql';
 import { useGetRunsFeed } from '@sorry-cypress/dashboard/run/runsFeed/useGetRunFeed';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
@@ -45,11 +48,9 @@ export function useGetTestsFromProject(project: any) {
   // We get the last run
   const lastRun = runsFeed?.runs[0];
   if (lastRun === undefined) return null;
-  const progress = lastRun?.progress;
-  const groups = progress?.groups;
-  let tests;
-  if (groups !== undefined && groups.length > 0) tests = groups[0].tests;
-  return tests;
+  const groups = lastRun?.progress?.groups;
+  if (!groups) return null;
+  return getRunTestsProgress(lastRun?.progress as RunProgress);
 }
 
 /**


### PR DESCRIPTION
Close #841 

- Added specific color instead of the default one (red, pink, etc..) to avoid painful UI for the user.
- Update projectListItem.tsx & projectList.tsx by renaming method.

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook).
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: https://github.com/sorry-cypress/sorry-cypress/issues/841

## Use case
See directly from the Project page all the failing/flaky/successful project test execution.

## Example
![image](https://github.com/sorry-cypress/sorry-cypress/assets/22171928/2672de4d-ed2c-4864-a428-7c300399c92d)
