### PR TITLE
fix: make docker-compose.minio.yml work without requiring changes

### DIFF
--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -2,8 +2,6 @@ version: '3.6'
 
 # Replace each <mongo-user> with the desired username
 # Replace each <mongo-pass> with the desired password
-# Replace each <minio-ip-address> with the publicly available ip address or url without http(s)
-# Replace <graphql-ip-address> with the publicly available ip address or url without http(s)
 
 services:
   mongo:
@@ -27,8 +25,8 @@ services:
       GITLAB_JOB_RETRIES: 'false'
       MINIO_ACCESS_KEY: '<minio-user>'
       MINIO_SECRET_KEY: '<minio-pass>'
-      MINIO_ENDPOINT: '<minio-ip-address>'
-      MINIO_URL: 'http://<minio-ip-address>'
+      MINIO_ENDPOINT: 'localhost'
+      MINIO_URL: 'http://localhost'
       MINIO_PORT: '9000'
       MINIO_USESSL: 'false'
       MINIO_BUCKET: sorry-cypress
@@ -54,7 +52,7 @@ services:
   dashboard:
     image: agoldis/sorry-cypress-dashboard:latest
     environment:
-      GRAPHQL_SCHEMA_URL: http://<graphql-ip-address>:4000
+      GRAPHQL_SCHEMA_URL: http://localhost:4000
       GRAPHQL_CLIENT_CREDENTIALS: ''
       PORT: 8080
       CI_URL: ''


### PR DESCRIPTION
-------

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook): This change doesn't require any change in documentation. In fact, the current documentation doesn't say anything about changing the docker-compose file so this PR improves the first-time experience by not requiring any change to this file.
- [ ] I have added included automated tests or evidence that it's working: There doesn't seem to be any automated test suite for the docker file.
- [ ] I acknowledge that I have tested that the change is backwards-compatible: Not sure what "backwards-compatible" means in this context.
- [ ] Original issue / feature request / discussion: `<here>`: None.

## Use case

While following the documentation at https://docs.sorry-cypress.dev/guide/dashboard-and-api, I tried to use the docker-compose file without changing it as no change what discussed in the documentation. Unfortunately, the docker-compose file did require some changes for it to work. I believe the new version of the docker-compose file doesn't need any change before it can be used. This should make the documentation easier to follow.

## Example

Not sure what to put here.