### PR TITLE
feat(minio): support for upload to proxied minio

### DIFF
--- a/packages/api/globalConfig.json
+++ b/packages/api/globalConfig.json
@@ -1,1 +1,1 @@
-{ "mongoUri": "mongodb://127.0.0.1:59537/" }
+{ "mongoUri": "mongodb://127.0.0.1:61418/" }

--- a/packages/director/src/screenshots/minio/config.ts
+++ b/packages/director/src/screenshots/minio/config.ts
@@ -4,6 +4,7 @@ export const MINIO_ACCESS_KEY =
 export const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'defaultSecret';
 export const MINIO_ACL = process.env.MINIO_ACL || 'public-read';
 export const MINIO_READ_URL_PREFIX = process.env.MINIO_READ_URL_PREFIX || null;
+export const MINIO_UPLOAD_URL_PREFIX = process.env.MINIO_UPLOAD_URL_PREFIX || null;
 export const MINIO_ENDPOINT =
   process.env.MINIO_ENDPOINT || 'storage.yourdomain.com';
 export const MINIO_PORT = process.env.MINIO_PORT || '9000';

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -45,7 +45,12 @@ export const getUploadUrl = async ({
         }
 
         if (MINIO_UPLOAD_URL_PREFIX) {
-          uploadUrl = replacePrefix(uploadUrl, MINIO_UPLOAD_URL_PREFIX, key);
+          uploadUrl = replacePrefix(
+            uploadUrl,
+            MINIO_UPLOAD_URL_PREFIX,
+            MINIO_BUCKET,
+            key
+          );
         }
 
         return resolve({
@@ -57,13 +62,16 @@ export const getUploadUrl = async ({
   });
 };
 
-const replacePrefix = (uploadUrl, prefix, key) => {
+const replacePrefix = (uploadUrl, prefix, bucket, key) => {
   // Minio is proxied and the internal minio api endpoint is not accessible externally
   // replace the http://minio:9000/{bucket}/{key}?{parameters}
   // with {MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
 
   const afterProtocol = uploadUrl.split('//').slice(1).join('//');
-  const afterKey = afterProtocol.split(`/${key}`).slice(1).join(`/${key}`);
+  const afterKey = afterProtocol
+    .split(`/${bucket}/${key}`)
+    .slice(1)
+    .join(`/${bucket}/${key}`);
   return `${prefix}/${key}${afterKey}`;
 };
 

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -47,7 +47,7 @@ export const getUploadUrl = async ({
         if (MINIO_UPLOAD_URL_PREFIX) {
           // Minio is proxied and the internal minio api endpoint is not accessible externally
           // replace the http://minio:9000/{bucket}/{key}?{parameters}
-          // with ${MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
+          // with {MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
           const parts = uploadUrl.split(`/${key}`)
           parts[0] = MINIO_UPLOAD_URL_PREFIX;
           uploadUrl = parts.join(`/${key}`)

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -7,6 +7,7 @@ import {
   MINIO_PORT,
   MINIO_READ_URL_PREFIX,
   MINIO_SECRET_KEY,
+  MINIO_UPLOAD_URL_PREFIX,
   MINIO_URL,
   MINIO_USESSL,
   UPLOAD_EXPIRY_SECONDS,
@@ -42,6 +43,16 @@ export const getUploadUrl = async ({
         if (error) {
           return reject(error);
         }
+        
+        if (MINIO_UPLOAD_URL_PREFIX) {
+          // Minio is proxied and the internal minio api endpoint is not accessible externally
+          // replace the http://minio:9000/{bucket}/{key}?{parameters}
+          // with ${MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
+          const parts = uploadUrl.split(`/${key}`)
+          parts[0] = MINIO_UPLOAD_URL_PREFIX;
+          uploadUrl = parts.join(`/${key}`)
+        }
+        
         return resolve({
           readUrl: `${MINIO_READ_URL_PREFIX || BUCKET_URL}/${key}`,
           uploadUrl,

--- a/packages/director/src/screenshots/minio/minio.ts
+++ b/packages/director/src/screenshots/minio/minio.ts
@@ -43,16 +43,11 @@ export const getUploadUrl = async ({
         if (error) {
           return reject(error);
         }
-        
+
         if (MINIO_UPLOAD_URL_PREFIX) {
-          // Minio is proxied and the internal minio api endpoint is not accessible externally
-          // replace the http://minio:9000/{bucket}/{key}?{parameters}
-          // with {MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
-          const parts = uploadUrl.split(`/${key}`)
-          parts[0] = MINIO_UPLOAD_URL_PREFIX;
-          uploadUrl = parts.join(`/${key}`)
+          uploadUrl = replacePrefix(uploadUrl, MINIO_UPLOAD_URL_PREFIX, key);
         }
-        
+
         return resolve({
           readUrl: `${MINIO_READ_URL_PREFIX || BUCKET_URL}/${key}`,
           uploadUrl,
@@ -60,6 +55,16 @@ export const getUploadUrl = async ({
       }
     );
   });
+};
+
+const replacePrefix = (uploadUrl, prefix, key) => {
+  // Minio is proxied and the internal minio api endpoint is not accessible externally
+  // replace the http://minio:9000/{bucket}/{key}?{parameters}
+  // with {MINIO_UPLOAD_URL_PREFIX}/{key}?{parameters}
+
+  const afterProtocol = uploadUrl.split('//').slice(1).join('//');
+  const afterKey = afterProtocol.split(`/${key}`).slice(1).join(`/${key}`);
+  return `${prefix}/${key}${afterKey}`;
 };
 
 export const getImageUploadUrl = async (


### PR DESCRIPTION
## Motivation:

In Kubernetes, if Minio is proxied, the generated presigned upload address could look something like
```
http://minio:9000/{bucket}/{key}?{parameters}
```

However that address is not accesssible outside the cluster, outside the cluster it should be for example

```
https://minio.localtest.me/{bucket}/{key}?{parameters}
```

Read URLs translation is already supported using the MINIO_READ_URL_PREFIX environment variable.

## Modifications:

Introduce an MINIO_UPLOAD_URL_PREFIX as well. Given `MINIO_UPLOAD_URL_PREFIX=https://minio.localtest.me/{bucket}` it will translate the presigned URL `http://minio:9000/{bucket}/{key}?{parameters}` to the externally accessible `https://minio.localtest.me/{bucket}/{key}?{parameters}`

## Results:

If the Ingress controller proxy sets the `Host` header to `minio:9000`. Minio presigned url signature validation will accept the upload.

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR https://github.com/sorry-cypress/gitbook/pull/32
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: See reasons for doing this below

## Use case

It is difficult to create a Sorry Cypress / Minio Kubernetes setup where all the services are hosted behind a single hostname. The Minio API endpoint is inside the cluster but the upload endpoint is outside. Also it is difficult to run 
a local setup without messing with port numbers and `/etc/hosts`.

## Example

If the director is configured

```
MINIO_READ_URL_PREFIX=http://minio.localtest.me/sorry-cypress
MINIO_UPLOAD_URL_PREFIX=http://minio.localtest.me/sorry-cypress
```

then the readUrl and presigned uploadUrl URL are at the same location

```
{"level":30,"time":1700033523811,"requestId":"74902818-6763-4cb7-bec8-1e8821f67302","instanceId":"71248ef7-b83d-49af-a8a8-7320aef6e7d7","screenshotUploadUrls":[],"videoUploadInstructions":{"readUrl":"http://minio.localtest.me/sorry-cypress/71248ef7-b83d-49af-a8a8-7320aef6e7d7.mp4","uploadUrl":"http://minio.localtest.me/sorry-cypress/71248ef7-b83d-49af-a8a8-7320aef6e7d7.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio-user%2F20231115%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231115T073203Z&X-Amz-Expires=90&X-Amz-SignedHeaders=host&X-Amz-Signature=4addbc79f267cbb2966658d1d8ff028cc18b9fbb6fd4e54a99da5f2963dc0934"},"msg":"Sending assets upload URLs"}
```

The translated uploadUrl is not directly valid, the host needs to be changed back to the original uploadUrl generated by the minio api. For example if the uploadUrl was generated inside a cluster using the minio endpoint at port 9000 and translated to an external address using the MINIO_UPLOAD_URL_PREFIX. Then an ingress controller at the external address will need to translate it back again for the signature of the presigned URL to be valid.

Ingress controllers are usually configured by annotations on an Ingress definition. For example the NGINX ingress controller will do this translation by adding the annotation
```
nginx.ingress.kubernetes.io/upstream-vhost: "minio:9000"
```

Other Ingress controllers and api gateways handle it slightly differently.

## Reason for doing this

I find it hard to configure Sorry-cypress screenshot uploads with Minio in kubernetes, this makes it easier.
