### PR TITLE
fix: resolve multiple illegal characters in document keys

### DIFF
--- a/packages/director/src/lib/__tests__/fixtures/issue-881.json
+++ b/packages/director/src/lib/__tests__/fixtures/issue-881.json
@@ -2,7 +2,7 @@
   "$schema$schema": {
     "value": "$schema$schema"
   },
-  "dot.dot.dor": {
+  "dot.dot.dot": {
     "value": "dot.dot.dot"
   }
 }

--- a/packages/director/src/lib/__tests__/fixtures/issue-XX.json
+++ b/packages/director/src/lib/__tests__/fixtures/issue-XX.json
@@ -1,0 +1,8 @@
+{
+  "$schema$schema": {
+    "value": "$schema$schema"
+  },
+  "dot.dot.dor": {
+    "value": "dot.dot.dot"
+  }
+}

--- a/packages/director/src/lib/__tests__/results.test.ts
+++ b/packages/director/src/lib/__tests__/results.test.ts
@@ -1,7 +1,7 @@
 import { getSanitizedMongoObject } from '../results';
 import fixture280 from './fixtures/issue-280.json';
 import fixture31 from './fixtures/issue-31.json';
-import fixtureXX from './fixtures/issue-XX.json';
+import fixtureXX from './fixtures/issue-881.json';
 
 describe('getSanitizedMongoObject', () => {
   test('should pass regression issue #280', () => {

--- a/packages/director/src/lib/__tests__/results.test.ts
+++ b/packages/director/src/lib/__tests__/results.test.ts
@@ -1,6 +1,7 @@
 import { getSanitizedMongoObject } from '../results';
 import fixture280 from './fixtures/issue-280.json';
 import fixture31 from './fixtures/issue-31.json';
+import fixtureXX from './fixtures/issue-XX.json';
 
 describe('getSanitizedMongoObject', () => {
   test('should pass regression issue #280', () => {
@@ -15,6 +16,12 @@ describe('getSanitizedMongoObject', () => {
     const result = getSanitizedMongoObject(fixture31);
     expect(result['dot_dot'].value).toEqual('dot.dot');
     expect(result['_schema'].value).toEqual('$schema');
+  });
+
+  test('should remove multiple occurrences of illegal characters', () => {
+    const result = getSanitizedMongoObject(fixtureXX);
+    expect(result['dot_dot_dot'].value).toEqual('dot.dot.dot');
+    expect(result['_schema_schema'].value).toEqual('$schema$schema');
   });
 
   test('should preserve arrays', () => {

--- a/packages/director/src/lib/results.ts
+++ b/packages/director/src/lib/results.ts
@@ -9,7 +9,7 @@ function sanitizeKey(_: string, value: any) {
   if (value && typeof value === 'object') {
     const replacement: Record<string, any> = {};
     for (const key in value) {
-      replacement[key.replace('$', '_').replace('.', '_')] = value[key];
+      replacement[key.replace(/\$/g, '_').replace(/\./g, '_')] = value[key];
     }
     return replacement;
   }


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link 
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible

## Use case

When config keys that contain multiple illegal characters an invalid name error is returned. This is because the current sanitise function only replaces the first example of an invalid character rather than every instance. This PR updates the replace function to a regex that globally searches.

## Example

### Before
![Screenshot 2023-11-16 at 12 02 06](https://github.com/sorry-cypress/sorry-cypress/assets/8171977/d527318f-1e62-409e-871f-4abd6cf5f783)

### After
![Screenshot 2023-11-16 at 12 02 22](https://github.com/sorry-cypress/sorry-cypress/assets/8171977/28159fa7-ec04-4721-8a9b-672da0ef5f18)

