### PR TITLE
feature(dashboard): release functional for disable reset button

### DIFF
--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -20,3 +20,4 @@ COPY --from=build /app/packages/dashboard/dist/views/index.ejs index.html
 ENV GRAPHQL_SCHEMA_URL "http://localhost:4000"
 ENV CI_URL ""
 ENV GRAPHQL_CLIENT_CREDENTIALS ""
+ENV RESET_DISABLED "false"

--- a/packages/dashboard/nginx/default.conf.template
+++ b/packages/dashboard/nginx/default.conf.template
@@ -1,6 +1,6 @@
 server {
 	include mime.types;
-	types 
+	types
 	{
 		application/javascript mjs;
 	}
@@ -8,6 +8,6 @@ server {
 	listen ${PORT} default_server;
 	root /usr/share/nginx/html;
 	try_files $uri /index.html;
-	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_CLIENT_CREDENTIALS: "${GRAPHQL_CLIENT_CREDENTIALS}", GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}" }';
-	sub_filter_once on;	
+	sub_filter '<?- SORRY_CYPRESS_ENVIRONMENT ?>' '{ GRAPHQL_CLIENT_CREDENTIALS: "${GRAPHQL_CLIENT_CREDENTIALS}", GRAPHQL_SCHEMA_URL: "${GRAPHQL_SCHEMA_URL}", CI_URL: "${CI_URL}", RESET_DISABLED: "${RESET_DISABLED}" }';
+	sub_filter_once on;
 }

--- a/packages/dashboard/server/app.js
+++ b/packages/dashboard/server/app.js
@@ -5,6 +5,7 @@ const {
   GRAPHQL_CLIENT_CREDENTIALS,
   GRAPHQL_SCHEMA_URL,
   CI_URL,
+  RESET_DISABLED,
   BASE_PATH,
 } = require('./config');
 
@@ -12,6 +13,7 @@ const SORRY_CYPRESS_ENVIRONMENT = JSON.stringify({
   GRAPHQL_CLIENT_CREDENTIALS,
   GRAPHQL_SCHEMA_URL,
   CI_URL,
+  RESET_DISABLED,
 });
 
 app.set('view engine', 'ejs');

--- a/packages/dashboard/server/config.js
+++ b/packages/dashboard/server/config.js
@@ -6,4 +6,5 @@ exports.GRAPHQL_SCHEMA_URL =
 exports.GRAPHQL_CLIENT_CREDENTIALS =
   process.env.GRAPHQL_CLIENT_CREDENTIALS || '';
 exports.CI_URL = process.env.CI_URL || '';
+exports.RESET_DISABLED = process.env.RESET_DISABLED || 'false';
 exports.BASE_PATH = process.env.BASE_PATH || '/';

--- a/packages/dashboard/src/run/runDetails/runDetails.tsx
+++ b/packages/dashboard/src/run/runDetails/runDetails.tsx
@@ -28,6 +28,7 @@ import React, { FunctionComponent, useMemo } from 'react';
 import { generatePath } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
 import stringHash from 'string-hash';
+import { environment } from '../../state/environment';
 
 export const RunDetails: RunDetailsComponent = (props) => {
   const { run, hidePassedSpecs, readableSpecNames } = props;
@@ -153,7 +154,7 @@ function convertToRows(
 
 const getActionsCell = (run: NonNullable<GetRunQuery['run']>) => {
   const getAction = (params: GridRenderCellParams) => {
-    return params.row.claimedAt ? (
+    return environment.RESET_DISABLED !== 'true' && params.row.claimedAt ? (
       <ResetInstanceButton
         spec={params.row.specName}
         instanceId={params.row.instanceId ?? 0}

--- a/packages/dashboard/src/state/environment.ts
+++ b/packages/dashboard/src/state/environment.ts
@@ -2,6 +2,7 @@ export interface Environment {
   GRAPHQL_CLIENT_CREDENTIALS: string;
   GRAPHQL_SCHEMA_URL: string;
   CI_URL: string;
+  RESET_DISABLED: string;
 }
 
 export const environment: Environment = {
@@ -9,6 +10,7 @@ export const environment: Environment = {
     GRAPHQL_CLIENT_CREDENTIALS: '',
     GRAPHQL_SCHEMA_URL: 'http://localhost:4000',
     CI_URL: '',
+    RESET_DISABLED: 'false',
   },
   ...((window.__sorryCypressEnvironment as Environment) || {}),
 };


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [ ] I have added included automated tests or evidence that it's working
- [ ] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case

Globally hide reset button

## Example

```
    environment:
      RESET_DISABLED: true
```

![image](https://github.com/sorry-cypress/sorry-cypress/assets/20482982/577fef58-b1e2-46b1-bdad-853cea96ac45)

These reset buttons are not visible

P.S. I didnt change API cuz you can use reset directly from API via REST. In my case - I only need to hide frontend buttons.