### PR TITLE
Add a new button to display only flaky tests

### DIFF
--- a/packages/dashboard/src/hooks/useShowFlakySpecs.ts
+++ b/packages/dashboard/src/hooks/useShowFlakySpecs.ts
@@ -1,0 +1,4 @@
+import { useLocalStorage } from './useLocalStorage';
+
+export const useShowFlakySpecs = () =>
+  useLocalStorage<boolean>('shouldShowFlakySpecs', false);

--- a/packages/dashboard/src/run/runDetails/runDetailsView.tsx
+++ b/packages/dashboard/src/run/runDetails/runDetailsView.tsx
@@ -1,5 +1,5 @@
 import {
-  FlakyRounded
+  FlakyRounded,
   Loop as LoopIcon,
   MenuBook as MenuBookIcon,
   VisibilityOff as VisibilityOffIcon,
@@ -19,6 +19,7 @@ import {
   ReadableSpecNamesKind,
   useReadableSpecNames,
 } from '@sorry-cypress/dashboard/hooks/useReadableSpecNames';
+import { useShowFlakySpecs } from '@sorry-cypress/dashboard/hooks/useShowFlakySpecs';
 import {
   getProjectPath,
   getRunPath,
@@ -29,7 +30,6 @@ import { RunSummary } from '@sorry-cypress/dashboard/run/runSummary/runSummary';
 import React, { FunctionComponent, useLayoutEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { RunDetails } from './runDetails';
-import { useShowFlakySpecs } from '@sorry-cypress/dashboard/hooks/useShowFlakySpecs';
 
 export const RunDetailsView: RunDetailsViewComponent = () => {
   const { id } = useParams();

--- a/packages/dashboard/src/run/runDetails/runDetailsView.tsx
+++ b/packages/dashboard/src/run/runDetails/runDetailsView.tsx
@@ -1,4 +1,5 @@
 import {
+  FlakyRounded
   Loop as LoopIcon,
   MenuBook as MenuBookIcon,
   VisibilityOff as VisibilityOffIcon,
@@ -28,11 +29,13 @@ import { RunSummary } from '@sorry-cypress/dashboard/run/runSummary/runSummary';
 import React, { FunctionComponent, useLayoutEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { RunDetails } from './runDetails';
+import { useShowFlakySpecs } from '@sorry-cypress/dashboard/hooks/useShowFlakySpecs';
 
 export const RunDetailsView: RunDetailsViewComponent = () => {
   const { id } = useParams();
   const autoRefreshRate = useAutoRefreshRate();
   const [hidePassedSpecs, setHidePassedSpecs] = useHideSuccessfulSpecs();
+  const [showFlakySpecs, setShowFlakySpecs] = useShowFlakySpecs();
   const [
     readableSpecNames,
     { switchReadableSpecNames },
@@ -118,6 +121,16 @@ export const RunDetailsView: RunDetailsViewComponent = () => {
             },
           },
           {
+            key: 'showFlakySpecs',
+            text: 'Show Only Flaky Specs',
+            icon: FlakyRounded,
+            selected: showFlakySpecs,
+            toggleButton: true,
+            onClick: () => {
+              setShowFlakySpecs(!showFlakySpecs);
+            },
+          },
+          {
             key: 'autoRefresh',
             text: 'Auto Refresh',
             icon: LoopIcon,
@@ -154,6 +167,7 @@ export const RunDetailsView: RunDetailsViewComponent = () => {
         key={readableSpecNames}
         run={data.run}
         hidePassedSpecs={hidePassedSpecs}
+        showFlakySpecs={showFlakySpecs}
         readableSpecNames={readableSpecNames}
       />
     </>

--- a/packages/director/src/lib/hooks/reporters/teams.ts
+++ b/packages/director/src/lib/hooks/reporters/teams.ts
@@ -54,6 +54,7 @@ export async function reportToTeams(
       break;
     case HookEvent.RUN_TIMEOUT:
       title = `:hourglass_flowing_sand: *Run timedout* (${ciBuildId})`;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       color = failureColor;
       break;
   }


### PR DESCRIPTION
## References

- [x] I have updated the [documentation](https://github.com/sorry-cypress/gitbook).
- [ ] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: [https://github.com/sorry-cypress/sorry-cypress/issues/822](https://github.com/sorry-cypress/sorry-cypress/issues/822)

## Use case

You can filter by all specs and hide successful specs but you need to check every spec and see the flaky icon to be able to filter by flaky tests. Now you have a button on the top as the hide successful specs button to filter only by the flaky tests. 

## Example

The incredible button was added and it's working as expected! :) 

<img width="732" alt="image" src="https://github.com/sorry-cypress/sorry-cypress/assets/6990209/7cd00bf6-6f11-4f19-9f3f-805d85158589">


