### PR TITLE
[Fix] Add showFlakySpecs to useMemo 

### DIFF
--- a/packages/dashboard/src/run/runDetails/runDetails.tsx
+++ b/packages/dashboard/src/run/runDetails/runDetails.tsx
@@ -39,8 +39,9 @@ export const RunDetails: RunDetailsComponent = (props) => {
   }
 
   const rows = useMemo(
-    () => convertToRows(run, hidePassedSpecs, showFlakySpecs, readableSpecNames),
-    [run, hidePassedSpecs]
+    () =>
+      convertToRows(run, hidePassedSpecs, showFlakySpecs, readableSpecNames),
+    [run, hidePassedSpecs, showFlakySpecs]
   );
 
   return (


### PR DESCRIPTION
## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case

After adding the filter by flaky specs button, we realised that it wasn't on the useMemo so you need to press reload in order to load the flaky specs. Now it's fixed. 

## Example

![Mar-26-2024 13-31-58](https://github.com/sorry-cypress/sorry-cypress/assets/6990209/94a7f5c1-7346-470b-9dcb-2ab61b0c3f7d)
