### PR TITLE
feat: Add optionnal operator to runs query to allow search on createdAt field

### DIFF
--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -2,7 +2,7 @@ export interface AggregationFilter {
   key: string;
   value: string | number | Date;
   operator?: 'gte' | 'gt' | 'lte' | 'lt'; // Make sure operator is included as an optional field
-  like?: string; // If your query includes 'like', this might be a separate field
+  like?: string;
 }
 
 export const filtersToAggregations = (filters?: AggregationFilter[]) => {

--- a/packages/api/src/lib/query.ts
+++ b/packages/api/src/lib/query.ts
@@ -1,19 +1,22 @@
 export interface AggregationFilter {
   key: string;
-  value?: string;
-  like?: string | null;
+  value: string | number | Date;
+  operator?: 'gte' | 'gt' | 'lte' | 'lt'; // Make sure operator is included as an optional field
+  like?: string; // If your query includes 'like', this might be a separate field
 }
 
 export const filtersToAggregations = (filters?: AggregationFilter[]) => {
   if (!filters) {
     return [];
   }
-  const match = {};
+  const match: any = {}; // 'any' type because we are dynamically adding keys
+
   filters
     .filter(({ like, value }) => like !== undefined || value !== undefined)
     .forEach((filter) => {
-      match[filter.key] = buildFilterExpression(filter);
+      match[filter.key] = buildFilterExpression(filter); // Apply the filter expression
     });
+
   return [
     {
       $match: match,
@@ -21,19 +24,46 @@ export const filtersToAggregations = (filters?: AggregationFilter[]) => {
   ];
 };
 
-const buildFilterExpression = ({ like, value }: AggregationFilter) => {
+// This is the function where we handle the operators
+const buildFilterExpression = ({
+  like,
+  value,
+  operator,
+}: AggregationFilter) => {
+  // Handle the operator case
+  if (operator) {
+    const operatorMap: { [key: string]: string } = {
+      gte: '$gte',
+      gt: '$gt',
+      lte: '$lte',
+      lt: '$lt',
+    };
+
+    if (operatorMap[operator]) {
+      // If the operator exists in our map, return the corresponding MongoDB expression
+      return {
+        [operatorMap[operator]]: value,
+      };
+    }
+  }
+
+  // If there's no operator, fallback to the value
   if (value !== undefined) {
     return value;
   }
+
+  // Handle 'like' if present (for text searches)
   if (like !== undefined && like !== null) {
     return {
       $regex: RegExp(like.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'i'),
     };
   }
-  return '';
+
+  return ''; // Default to empty if no filter is applied
 };
 
 export type OrderDirection = 'ASC' | 'DESC';
+
 export const getSortByAggregation = (direction: OrderDirection = 'DESC') => ({
   $sort: {
     _id: direction === 'DESC' ? -1 : 1,

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -97,8 +97,39 @@ export const resolvers = {
       { orderDirection, filters }: Parameters<RunsAPI['getAllRuns']>[0],
       { dataSources }: { dataSources: AppDatasources }
     ) => {
+      // If there are filters, process each one
+      if (filters && filters.length > 0) {
+        filters.forEach((filter) => {
+          // Specifically check for 'createdAt' field
+          if (filter.key === 'createdAt') {
+            // Ensure filter.value is not undefined or null
+            if (filter.value) {
+              // Handle the operator for createdAt (gte, gt, lte, lt)
+              switch (filter.operator) {
+                case 'gte': // Greater than or equal to
+                case 'gt': // Greater than
+                case 'lte': // Less than or equal to
+                case 'lt': // Less than
+                  // Ensure filter.value is a valid date before creating Date object
+                  filter.value = new Date(filter.value).toISOString(); // Convert to ISO string if valid
+                  break;
+                default:
+                  // If the operator is not recognized, throw an error or skip processing
+                  throw new Error(
+                    `Unsupported operator for createdAt: ${filter.operator}`
+                  );
+              }
+            } else {
+              throw new Error('Invalid value for createdAt filter');
+            }
+          }
+        });
+      }
+
+      // Pass the modified filters to the data source for querying
       return dataSources.runsAPI.getAllRuns({ orderDirection, filters });
     },
+
     ciBuilds: (
       _: any,
       { filters }: Parameters<RunsAPI['getAllCiBuilds']>[0],

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -276,4 +276,5 @@ input Filters {
   key: String
   value: String
   like: String
+  operator: String
 }


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [ ] Original issue / feature request / discussion: `<here>`

## Use case
When searching for runs, we currently can't search for runs based on their creation date. This create an issue when calling the API because it generates a huge load and can OOMKill a pod for example.

This feature allows to search for run that were created before or after a certain date passer in the filter, as seen in the screenshots
An operator is mandatory when using createdAt in the filter

## Example

> Submit screenshots / outputs / tests together with the PR.
You can see the runs fetched after a certain date
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b117a9b0-324a-40c0-8348-58d9de6c2475" />
Then, before the same date
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/7dde1d2c-353f-4863-9880-d024161141fb" />

This screenshot show backward-compatible as the filter is optionnal
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d259ce04-ddba-42cb-89ac-ed5b8a0363da" />
