### PR TITLE
Fix api error non-nullable field InstanceStats.wallClockDuration

### DIFF
--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -15,6 +15,7 @@ services:
       - ./data/data-mongo-cypress:/data/db
     ports:
       - 27017:27017
+
   director:
     image: agoldis/sorry-cypress-director:latest
     environment:
@@ -32,7 +33,7 @@ services:
       MINIO_PORT: '9000'
       MINIO_USESSL: 'false'
       MINIO_BUCKET: sorry-cypress
-      PROBE_LOGGER: "false"
+      PROBE_LOGGER: 'false'
     ports:
       - 1234:1234
       - 9000:9000

--- a/packages/api/src/schema/schema.graphql
+++ b/packages/api/src/schema/schema.graphql
@@ -202,9 +202,9 @@ type InstanceStats {
   pending: Int!
   skipped: Int!
   failures: Int!
-  wallClockStartedAt: String!
-  wallClockEndedAt: String!
-  wallClockDuration: Int!
+  wallClockStartedAt: String
+  wallClockEndedAt: String
+  wallClockDuration: Int
 }
 
 type CypressConfig {


### PR DESCRIPTION
> PRs that do not follow the template will be automatically closed

## References

- [ ] I have updated the [documentation](https://github.com/sorry-cypress/gitbook). PR link `<here>`
- [x] I have added included automated tests or evidence that it's working
- [x] I acknowledge that I have tested that the change is backwards-compatible
- [x] Original issue / feature request / discussion: `[<here>](https://github.com/sorry-cypress/sorry-cypress/discussions/901)`

## Use case

When going to the test results, an error is shown  (presumably, when using cypress >= 13)

## Example

"Cannot return null for non-nullable field InstanceStats.wallClockDuration"
